### PR TITLE
Redesign binding scope, expand AgentTool, surface sandbox diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ end
 - **Sandboxed Execution** - Generated code runs in a restricted environment with controlled access to tools. You have full control over which tools are exposed to which agents, and you can monitor agent behavior using the [`legion_web`](https://github.com/dimamik/legion_web) dashboard.
 - **Simple Tool Definition** - Expose any Elixir module as a tool with `use Legion.Tool`. This allows you to reuse your existing app's logic. If you want to expose a third-party module as a set of tools, you can do that too.
 - **Authorization baked in** - The safest way to authorize tool calls via the [`Vault`](https://github.com/dimamik/vault) library. Put all data needed to authorize an LLM call before starting the agent, and validate it inside the tool call. Everything will be available due to `Vault`'s nature.
-- **Long-lived Agents** - Treat your agents as [GenServers](https://hexdocs.pm/elixir/GenServer.html), context is preserved naturally. Start your agent with `Legion.start_link/2`, just as you'd start a [GenServer](https://hexdocs.pm/elixir/GenServer.html). Agents reference variables across turns (tasks) by default - disable `share_bindings` if you need each turn to start fresh.
+- **Long-lived Agents** - Treat your agents as [GenServers](https://hexdocs.pm/elixir/GenServer.html), context is preserved naturally. Start your agent with `Legion.start_link/2`, just as you'd start a [GenServer](https://hexdocs.pm/elixir/GenServer.html). Each turn starts with a clean slate by default; set `binding_scope: :conversation` to reference variables from previous turns.
 - **Multi-Agent Systems** - Agents can orchestrate other agents, letting you create complex systems that manage themselves. Agents spawn other agents as linked processes — when a parent dies, all children are stopped too. Your agent is just another BEAM process.
 - **Human in the Loop** - Human-in-the-loop is just a built-in tool called `HumanTool`. You could have written it yourself, but I wrote it for you. It just blocks the agent's execution until it receives a message from the user. Simple as that.
 - **Structured Output** - Define schemas to get typed, validated responses from agents, or omit types and operate on plain text. You have full control over prompts and schemas.
@@ -136,18 +136,24 @@ config :legion, :config, %{
   max_iterations: 10,
   max_retries: 3,
   sandbox_timeout: 60_000,
-  share_bindings: true
+  binding_scope: :turn,
+  max_message_length: 20_000
 }
 ```
 
 - **Iterations** are successful execution steps - the agent fetches data, processes it, calls another tool, etc. Each productive action counts as one iteration.
 - **Retries** are consecutive failures - when the LLM generates invalid code or a tool raises an error. The counter resets after each successful iteration.
-- **share_bindings** — when `true` (the default), variable bindings from code execution carry over between turns in a long-lived agent. For example, if the LLM assigns `posts = ScraperTool.fetch_posts()` in one turn, the `posts` variable will be available in the next turn. Set to `false` if each turn should start with a clean slate.
+- **binding_scope** — how long variable bindings from code execution live. Three levels, nested from narrowest to widest:
+  - `:iteration` — every code execution starts fresh. A variable defined in one `eval_and_continue` step is *not* visible in the next step of the same turn.
+  - `:turn` (default) — variables persist across iterations within one turn but reset between turns.
+  - `:conversation` — variables persist for the entire conversation. If the LLM assigns `posts = ScraperTool.fetch_posts()` in one turn, `posts` is still available in later turns.
+- **max_message_length** — max byte size of any single message added to the conversation (user input, code execution results, and error text). Longer content is truncated with a `[... truncated N bytes ...]` marker so a stray large payload cannot blow up the context. Set to `:infinity` to disable.
 
 Agents can override global settings:
 
 ```elixir
 defmodule MyApp.DataAgent do
+  @moduledoc "Fetches and processes data from HTTP APIs."
   use Legion.Agent
 
   def tools, do: [MyApp.HTTPTool]
@@ -170,6 +176,7 @@ All callbacks are optional with sensible defaults:
 
 ```elixir
 defmodule MyApp.DataAgent do
+  @moduledoc "Fetches and processes data from HTTP APIs."
   use Legion.Agent
 
   def tools, do: [MyApp.HTTPTool]
@@ -186,13 +193,61 @@ defmodule MyApp.DataAgent do
     }
   end
 
-  # Additional instructions for the LLM
+  # Replaces the entire auto-generated system prompt. Only override when you
+  # want full control - otherwise rely on @moduledoc and tool descriptions.
   def system_prompt do
-    "Always validate URLs before fetching. Prefer JSON responses."
+    "You are a data fetcher. Always validate URLs before fetching. Prefer JSON responses."
   end
 
   # Pass options to specific tools (accessible via Vault)
   def tool_config(MyApp.HTTPTool), do: [timeout: 10_000]
+end
+```
+
+## Third-Party Modules as Tools
+
+You can expose third-party modules (e.g. `Req`, `Jason`) as tools directly, without wrapping them. Since the module's source lives outside your project, Legion needs to be told to read it at compile time. Register the modules in your config:
+
+```elixir
+# config/config.exs
+config :legion, extra_source_modules: [Req, Jason]
+```
+
+Then list the module in your agent's `tools/0` like any other tool:
+
+```elixir
+defmodule MyApp.APIAgent do
+  @moduledoc "Fetches data from JSON APIs and decodes responses."
+  use Legion.Agent
+
+  def tools, do: [Req, Jason]
+end
+```
+
+The LLM receives the module's full source as the tool description and can call any public function inside the sandbox.
+
+Prefer a thin facade module using `use Legion.Tool` with a hand-written `description/0` when:
+
+- You want to expose only a subset of the library's API.
+- The library is large and injecting its entire source into the prompt would be wasteful.
+- You want a curated, LLM-friendly description rather than raw source.
+
+```elixir
+defmodule MyApp.Tools.JSONTool do
+  use Legion.Tool
+
+  def description do
+    """
+    JSONTool - encode and decode JSON.
+
+    ## Functions
+    - `encode!(term)` - returns a JSON string, raises on invalid input.
+    - `decode!(binary)` - returns a decoded term, raises on invalid JSON.
+    """
+  end
+
+  defdelegate encode!(term), to: Jason
+  defdelegate decode!(binary), to: Jason
 end
 ```
 
@@ -257,6 +312,7 @@ Agents can spawn and communicate with other agents using the built-in `AgentTool
 
 ```elixir
 defmodule MyApp.OrchestratorAgent do
+  @moduledoc "Coordinates research and writing sub-agents to produce finished content."
   use Legion.Agent
 
   def tools, do: [Legion.Tools.AgentTool, MyApp.Tools.DatabaseTool]

--- a/lib/legion/agent.ex
+++ b/lib/legion/agent.ex
@@ -40,8 +40,15 @@ defmodule Legion.Agent do
       - `max_iterations` — max successful execution steps per turn (default: `10`)
       - `max_retries` — max consecutive failures before giving up (default: `3`)
       - `sandbox_timeout` — timeout in ms for code execution (default: `60_000`)
-      - `share_bindings` — when `true`, variable bindings persist across turns
-        in a long-lived agent (default: `true`)
+      - `binding_scope` — how long variable bindings from code execution live
+        (default: `:turn`):
+        - `:iteration` — bindings reset between every code execution
+        - `:turn` — bindings persist across iterations within one turn, reset between turns
+        - `:conversation` — bindings persist for the entire conversation (across turns)
+      - `max_message_length` — max byte size of a single message added to the
+        conversation (user input, code execution result, or error text). Longer
+        content is truncated with a `[... truncated N bytes ...]` marker.
+        Defaults to `20_000`. Set to `:infinity` to disable truncation.
 
     - `action_types/0` — list of action strings the LLM is allowed to respond with.
       Defaults to all four: `~w(eval_and_continue eval_and_complete return done)`.

--- a/lib/legion/agent_prompt.ex
+++ b/lib/legion/agent_prompt.ex
@@ -10,13 +10,15 @@ defmodule Legion.AgentPrompt do
   def system_prompt(agent) do
     tool_contents = Enum.map(agent.tools(), &tool_description/1)
     description = agent.moduledoc()
+    binding_scope = Map.get(agent.config(), :binding_scope, :turn)
 
     {result, _} =
       Code.eval_quoted(@template,
         description: description,
         tool_contents: tool_contents,
         action_types: agent.action_types(),
-        elixir_version: System.version()
+        elixir_version: System.version(),
+        binding_scope: binding_scope
       )
 
     String.trim(result)
@@ -25,10 +27,14 @@ defmodule Legion.AgentPrompt do
   defp tool_description(module) do
     Code.ensure_loaded!(module)
 
-    if function_exported?(module, :description, 0) do
-      module.description()
-    else
-      Legion.SourceRegistry.source!(module)
-    end
+    content =
+      if function_exported?(module, :description, 0) do
+        module.description()
+      else
+        Legion.SourceRegistry.source!(module)
+      end
+
+    short_name = module |> Module.split() |> List.last()
+    {short_name, String.trim(content)}
   end
 end

--- a/lib/legion/agent_server.ex
+++ b/lib/legion/agent_server.ex
@@ -1,16 +1,10 @@
 defmodule Legion.AgentServer do
-  @moduledoc """
-  GenServer that maintains conversation history for a long-lived agent.
+  @moduledoc false
 
-  Holds the message history across multiple turns. Each `call` or `cast`
-  appends the user message and runs `Executor` to completion (blocking).
-
-  ## Usage
-
-      {:ok, pid} = Legion.start_link(MyAgent)
-      {:ok, result} = Legion.call(pid, "Do something")
-      Legion.cast(pid, "Follow-up (fire and forget)")
-  """
+  # GenServer that maintains conversation history for a long-lived agent.
+  #
+  # Holds the message history across multiple turns. Each `call` or `cast`
+  # appends the user message and runs `Executor` to completion (blocking).
 
   use GenServer
 
@@ -26,7 +20,8 @@ defmodule Legion.AgentServer do
   def start_link(agent_module, opts \\ []) do
     {name, opts} = Keyword.pop(opts, :name)
     gen_opts = if name, do: [name: name], else: []
-    GenServer.start_link(__MODULE__, {agent_module, opts}, gen_opts)
+    config = resolve_config(agent_module, opts)
+    GenServer.start_link(__MODULE__, {agent_module, config}, gen_opts)
   end
 
   def call(agent, message, timeout \\ :infinity) do
@@ -44,7 +39,7 @@ defmodule Legion.AgentServer do
   # Server callbacks
 
   @impl true
-  def init({agent_module, opts}) do
+  def init({agent_module, config}) do
     parent_run_id = Vault.get(:run_id)
     run_id = make_ref()
 
@@ -56,7 +51,6 @@ defmodule Legion.AgentServer do
     end
 
     system_prompt = agent_module.system_prompt()
-    config = resolve_config(agent_module, opts)
 
     Telemetry.emit(
       [:legion, :agent, :started],
@@ -88,33 +82,53 @@ defmodule Legion.AgentServer do
   end
 
   @impl true
-  def handle_call({:message, msg}, _from, state) do
-    {reply, state} = handle_message(msg, state)
+  def handle_call({:message, message}, _from, state) do
+    {reply, state} = handle_message(message, state)
     {:reply, reply, state}
   end
 
   @impl true
-  def handle_cast({:message, msg}, state) do
-    {_reply, state} = handle_message(msg, state)
+  def handle_cast({:message, message}, state) do
+    {_reply, state} = handle_message(message, state)
     {:noreply, state}
   end
 
-  defp handle_message(msg, state) do
+  @doc """
+  Normalizes `message`, appends it to the conversation, and runs the executor
+  to completion. Returns `{{status, value}, new_state}`.
+
+  Accepted `message` shapes:
+    - `binary` - passed verbatim as the user message
+    - `{:image, data, media_type}` - single inline image from binary data
+    - `{:image_url, url}` - single image from a URL
+    - `{:multipart, [ContentPart.t()]}` - mixed text/image/file content; build
+      parts with `ReqLLM.Message.ContentPart.text/1`, `image/2`, `image_url/1`,
+      `file/3`
+    - `struct` - `__struct__` and `__meta__` are dropped, then JSON-encoded
+    - `map | list` - JSON-encoded
+    - anything else - `inspect/2` fallback (lossy; prefer the shapes above)
+  """
+  def handle_message(message, state) do
+    content =
+      message |> stringify() |> Executor.truncate_content(state.config[:max_message_length])
+
     {status, value, final_messages, final_bindings} =
       Telemetry.span(
         [:legion, :agent, :message],
-        %{agent: state.agent_module, message: msg},
+        %{agent: state.agent_module, message: content},
         fn ->
-          messages = state.messages ++ [%{role: "user", content: stringify(msg)}]
+          messages = state.messages ++ [%{role: "user", content: content}]
           prev_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
           initial_bindings =
-            if Map.get(state.config, :share_bindings, true), do: state.bindings, else: []
+            if Map.get(state.config, :binding_scope, :turn) == :conversation,
+              do: state.bindings,
+              else: []
 
-          {status, value, msgs, bindings} =
+          {status, value, messages, bindings} =
             result = Executor.run(state.agent_module, messages, state.config, initial_bindings)
 
-          iterations = Enum.count(msgs, &(&1[:role] == "assistant")) - prev_count
+          iterations = Enum.count(messages, &(&1[:role] == "assistant")) - prev_count
           {result, %{iterations: iterations, status: status, result: value, bindings: bindings}}
         end
       )
@@ -122,7 +136,7 @@ defmodule Legion.AgentServer do
     {{status, value}, %{state | messages: final_messages, bindings: final_bindings}}
   end
 
-  defp stringify(msg) when is_binary(msg), do: msg
+  defp stringify(message) when is_binary(message), do: message
 
   defp stringify({:image, data, media_type}) when is_binary(data) and is_binary(media_type) do
     [ContentPart.image(data, media_type)]
@@ -134,9 +148,18 @@ defmodule Legion.AgentServer do
 
   defp stringify({:multipart, parts}) when is_list(parts), do: parts
 
-  defp stringify(msg), do: inspect(msg, pretty: true, limit: :infinity)
+  defp stringify(%_{} = message) do
+    message
+    |> Map.from_struct()
+    |> Map.drop([:__meta__])
+    |> Jason.encode!()
+  end
 
-  @known_config_keys ~w(model max_iterations max_retries sandbox_timeout share_bindings)a
+  defp stringify(message) when is_map(message) or is_list(message), do: Jason.encode!(message)
+
+  defp stringify(message), do: inspect(message, pretty: true, limit: :infinity)
+
+  @known_config_keys ~w(binding_scope max_iterations max_message_length max_retries model sandbox_timeout)a
 
   defp resolve_config(agent_module, opts) do
     app_config = Application.get_env(:legion, :config, %{})
@@ -149,6 +172,20 @@ defmodule Legion.AgentServer do
       Logger.warning("Unknown Legion config keys: #{inspect(unknown)}")
     end
 
+    validate_max_message_length(merged)
+
     merged
   end
+
+  defp validate_max_message_length(%{max_message_length: :infinity}), do: :ok
+
+  defp validate_max_message_length(%{max_message_length: n}) when is_integer(n) and n > 0,
+    do: :ok
+
+  defp validate_max_message_length(%{max_message_length: other}) do
+    raise ArgumentError,
+          "expected :max_message_length to be a positive integer or :infinity, got: #{inspect(other)}"
+  end
+
+  defp validate_max_message_length(_config), do: :ok
 end

--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -16,14 +16,17 @@ defmodule Legion.Executor do
     max_iterations: 10,
     max_retries: 3,
     sandbox_timeout: 60_000,
-    share_bindings: true
+    binding_scope: :turn,
+    max_message_length: 20_000
   }
 
   @action_descriptions %{
-    "eval_and_continue" => "Execute code and continue. Use when you need the result to proceed.",
-    "eval_and_complete" => "Execute code and return its result as the final answer.",
+    "eval_and_continue" =>
+      "Execute code and continue the turn. Use when you need the result before deciding the next step.",
+    "eval_and_complete" =>
+      "Finish the turn with the code's result. Use when the final answer comes from executing code.",
     "return" =>
-      "Return a structured result without code execution. This finishes your turn, return this only when you're done with the task. If you're encountering code evaluation errors - adjust the code and re-run it.",
+      "Finish the turn with a structured result and no code execution. Only use when the task is fully done - not to report in-progress work or bail out of execution errors (fix the code and re-run instead).",
     "done" => "Task complete with no result to return."
   }
 
@@ -140,8 +143,8 @@ defmodule Legion.Executor do
         case ReqLLM.generate_object(config.model, messages, action_schema(agent_module)) do
           {:ok, response} ->
             action = extract_object(response)
-            msgs = messages ++ [%{role: "assistant", content: Jason.encode!(action)}]
-            {{:ok, action, msgs}, %{object: action}}
+            messages = messages ++ [%{role: "assistant", content: Jason.encode!(action)}]
+            {{:ok, action, messages}, %{object: action}}
 
           {:error, reason} ->
             {{:error, "LLM request failed: #{inspect(reason)}"}, %{error: reason}}
@@ -176,7 +179,10 @@ defmodule Legion.Executor do
        when eval in ["eval_and_continue", "eval_and_complete"] and code != "" do
     case eval_in_span(agent, code, config, bindings) do
       {:ok, {result, new_bindings}} ->
-        messages = messages ++ [%{role: "user", content: format_result(result, new_bindings)}]
+        new_bindings = if config.binding_scope == :iteration, do: [], else: new_bindings
+
+        messages =
+          messages ++ [%{role: "user", content: format_result(result, new_bindings, config)}]
 
         if eval == "eval_and_continue",
           do: loop(agent, messages, config, i + 1, 0, new_bindings),
@@ -201,7 +207,9 @@ defmodule Legion.Executor do
 
   defp eval_in_span(agent_module, code, config, bindings) do
     Telemetry.span([:legion, :sandbox, :eval], %{agent: agent_module, code: code}, fn ->
-      allowed = agent_module.tools()
+      tools = agent_module.tools()
+      extras = Enum.flat_map(tools, & &1.extra_allowed_modules())
+      allowed = tools ++ extras
 
       case Sandbox.execute(code, config.sandbox_timeout, allowed, bindings) do
         {:ok, {value, new_bindings}} ->
@@ -217,7 +225,7 @@ defmodule Legion.Executor do
     if retries >= config.max_retries do
       {:cancel, :reached_max_retries, messages, bindings}
     else
-      error_text = format_error(error)
+      error_text = error |> format_error() |> truncate_content(config[:max_message_length])
 
       messages =
         messages ++
@@ -258,24 +266,40 @@ defmodule Legion.Executor do
 
   defp extract_object(_response), do: raise("LLM response contained no structured object")
 
-  defp format_result(result, bindings) do
-    var_names = bindings |> Keyword.keys() |> Enum.map(&"`#{&1}`")
+  defp format_result(result, bindings, config) do
+    variable_names = bindings |> Keyword.keys() |> Enum.map(&"`#{&1}`")
+
+    inspected =
+      result
+      |> inspect(pretty: true, limit: 1000)
+      |> truncate_content(config[:max_message_length])
 
     base = """
     Code executed successfully. Result:
     ```
-    #{inspect(result, pretty: true, limit: 1000)}
+    #{inspected}
     ```
     """
 
-    if var_names == [] do
+    if variable_names == [] do
       base
     else
-      base <> "\nAvailable variables: #{Enum.join(var_names, ", ")}"
+      base <> "\nAvailable variables: #{Enum.join(variable_names, ", ")}"
     end
   end
 
-  defp format_error(%{message: msg}) when is_binary(msg), do: msg
+  defp format_error(message) when is_binary(message), do: message
+  defp format_error(%{message: message}) when is_binary(message), do: message
   defp format_error(error) when is_exception(error), do: Exception.message(error)
   defp format_error(error), do: inspect(error, pretty: true, limit: 50)
+
+  @doc false
+  def truncate_content(content, :infinity), do: content
+
+  def truncate_content(content, max)
+      when is_binary(content) and is_integer(max) and byte_size(content) > max do
+    binary_part(content, 0, max) <> "\n\n[... truncated #{byte_size(content) - max} bytes ...]"
+  end
+
+  def truncate_content(content, _max), do: content
 end

--- a/lib/legion/prompts/system_prompt.eex
+++ b/lib/legion/prompts/system_prompt.eex
@@ -11,9 +11,7 @@ For each step, you respond with a JSON object containing:
 
 **Constraints:** You cannot define modules (`defmodule`) or functions (`def`, `defp`) in your code.
 
-**Variables persist between steps.** When you use `eval_and_continue`, any variables you define are available in subsequent code executions within the same turn. After each execution, you'll see which variables are available.
-
-**Variables also persist across turns** in long-lived agents (when `share_bindings` is enabled, which is the default). A variable you assigned while handling an earlier user message is still in scope when handling the next one - you can reference it directly instead of recomputing it.
+<%= if binding_scope == :iteration do %>**Variables do not persist.** Each code execution starts with a clean slate - variables defined in one execution are not available in the next.<% else %>**Variables persist.** When you use `eval_and_continue`, any variables you define are available in subsequent code executions within the same turn. After each execution, you'll see which variables are available.<%= if binding_scope == :conversation do %> Variables also persist across turns - a variable you assigned while handling an earlier user message is still in scope when handling the next one, so you can reference it directly instead of recomputing it.<% end %><% end %>
 
 ## Who are you
 
@@ -22,5 +20,10 @@ For each step, you respond with a JSON object containing:
 <%= if tool_contents != [] do %>
 ## Available Tools
 
-<%= Enum.map_join(tool_contents, "\n\n", fn content -> "```elixir\n#{content}\n```" end) %>
+Each tool below is a module aliased to its short name in the sandbox - call it as `ShortName.fun(...)`.
+
+<%= Enum.map_join(tool_contents, "\n\n", fn {name, content} ->
+  lang = if String.starts_with?(content, "defmodule"), do: "elixir", else: ""
+  "### #{name}\n\n````#{lang}\n#{content}\n````"
+end) %>
 <% end %>

--- a/lib/legion/sandbox.ex
+++ b/lib/legion/sandbox.ex
@@ -64,18 +64,20 @@ defmodule Legion.Sandbox do
 
     {pid, ref} =
       spawn_monitor(fn ->
-        result =
-          try do
-            {value, new_bindings} = Code.eval_string(code_string, bindings)
-            {:ok, {value, new_bindings}}
-          rescue
-            e -> {:error, e}
-          catch
-            :throw, value -> {:error, {:throw, value}}
-            :exit, reason -> {:error, {:exit, reason}}
-          end
+        {result, diagnostics} =
+          Code.with_diagnostics(fn ->
+            try do
+              {value, new_bindings} = Code.eval_string(code_string, bindings)
+              {:ok, {value, new_bindings}}
+            rescue
+              e -> {:error, e}
+            catch
+              :throw, value -> {:error, {:throw, value}}
+              :exit, reason -> {:error, {:exit, reason}}
+            end
+          end)
 
-        send(parent, {:result, self(), result})
+        send(parent, {:result, self(), attach_diagnostics(result, diagnostics)})
       end)
 
     receive do
@@ -92,4 +94,20 @@ defmodule Legion.Sandbox do
         {:error, :timeout}
     end
   end
+
+  defp attach_diagnostics({:error, %CompileError{}}, [_ | _] = diagnostics) do
+    {:error, format_diagnostics(diagnostics)}
+  end
+
+  defp attach_diagnostics(result, _diagnostics), do: result
+
+  defp format_diagnostics(diagnostics) do
+    Enum.map_join(diagnostics, "\n", fn diag ->
+      "#{format_position(diag.position)}: #{diag.message}"
+    end)
+  end
+
+  defp format_position({line, column}), do: "#{line}:#{column}"
+  defp format_position(line) when is_integer(line), do: "#{line}"
+  defp format_position(_), do: "?"
 end

--- a/lib/legion/sandbox/ast_checker.ex
+++ b/lib/legion/sandbox/ast_checker.ex
@@ -3,20 +3,28 @@ defmodule Legion.Sandbox.ASTChecker do
   Static safety check for sandboxed code.
 
   Parses a code string into an AST and walks every node with `Macro.prewalk/3`,
-  rejecting the first violation found. Two categories of violations are checked:
+  rejecting the first violation found. Three categories of violations are checked:
 
-  - **Forbidden forms** — language constructs that could escape the sandbox:
-    `alias`, `import`, `require`, `use`, `quote`/`unquote`, `defmodule`,
-    `defmacro`, `defprotocol`, `send`, `receive`, `spawn`, `spawn_link`,
-    `spawn_monitor`, `__ENV__`.
-  - **Disallowed module calls** — any `Module.function()` or `:erlang_mod.function()`
+  - **Forbidden forms** - language constructs that could escape the sandbox:
+    `alias`, `import`, `require`, `use`, `quote`/`unquote`, `def`, `defp`,
+    `defmodule`, `defmacro`, `defprotocol`, `send`, `receive`, `spawn`,
+    `spawn_link`, `spawn_monitor`, `apply`, `__ENV__`.
+  - **Forbidden `Kernel` functions** - even though `Kernel` is allowed as a
+    module, these specific functions are rejected: `spawn`, `spawn_link`,
+    `spawn_monitor`, `send`, `apply`, `exit`.
+  - **Forbidden `:erlang` functions** - `:erlang` is allowed as a module, but
+    these functions are rejected: `spawn`, `spawn_link`, `spawn_monitor`,
+    `send`, `apply`, `exit`, `halt`, `open_port`, `ports`, `port_command`,
+    `get`, `put`, `process_flag`, `list_to_atom`, `system_info`.
+  - **Disallowed module calls** - any `Module.function()` or `:erlang_mod.function()`
     call where the module is not in the built-in safe list or the caller-supplied
     allow-list.
 
-  Built-in safe modules: `Kernel`, `String`, `Enum`, `Map`, `MapSet`, `List`,
-  `Keyword`, `Tuple`, `Integer`, `Float`, `Atom`, `Regex`, `Range`, `Access`,
-  `Stream`, `Date`, `DateTime`, `NaiveDateTime`, `Time`, `:erlang` (with
-  dangerous functions blocked), `:math`, `:binary`, `:lists`, `:maps`, `:string`.
+  Built-in safe modules: `Kernel` (with forbidden functions above), `String`,
+  `Enum`, `Map`, `MapSet`, `List`, `Keyword`, `Tuple`, `Integer`, `Float`,
+  `Atom`, `Regex`, `Range`, `Access`, `Stream`, `Date`, `DateTime`,
+  `NaiveDateTime`, `Time`, `Calendar`, `:erlang` (with forbidden functions
+  above), `:math`, `:binary`, `:lists`, `:maps`, `:string`.
   """
 
   @builtin_allowed [
@@ -39,6 +47,7 @@ defmodule Legion.Sandbox.ASTChecker do
     DateTime,
     NaiveDateTime,
     Time,
+    Calendar,
     :erlang,
     :math,
     :binary,
@@ -47,7 +56,7 @@ defmodule Legion.Sandbox.ASTChecker do
     :string
   ]
 
-  @forbidden_forms ~w(alias quote unquote defmodule defmacro defprotocol import require use send receive spawn spawn_link spawn_monitor apply __ENV__)a
+  @forbidden_forms ~w(alias quote unquote def defp defmodule defmacro defprotocol import require use send receive spawn spawn_link spawn_monitor apply __ENV__)a
 
   @forbidden_kernel_functions ~w(spawn spawn_link spawn_monitor send apply exit)a
 
@@ -69,8 +78,8 @@ defmodule Legion.Sandbox.ASTChecker do
     case Code.string_to_quoted(code_string) do
       {:ok, ast} ->
         alias_tails =
-          Enum.map(allowed_modules, fn mod ->
-            mod |> Module.split() |> List.last() |> then(&Module.concat([&1]))
+          Enum.map(allowed_modules, fn module ->
+            module |> Module.split() |> List.last() |> then(&Module.concat([&1]))
           end)
 
         allowed = @builtin_allowed ++ allowed_modules ++ alias_tails
@@ -82,7 +91,7 @@ defmodule Legion.Sandbox.ASTChecker do
     end
   end
 
-  defp check_node(node, {:error, _} = err, _allowed), do: {node, err}
+  defp check_node(node, {:error, _} = error, _allowed), do: {node, error}
 
   # Elixir module calls: ModuleName.function(...)
   defp check_node({{:., _, [{:__aliases__, _, parts}, func]}, _, _} = node, :ok, allowed) do
@@ -101,12 +110,12 @@ defmodule Legion.Sandbox.ASTChecker do
   end
 
   # Erlang module calls: :atom.function(...)
-  defp check_node({{:., _, [mod, func]}, _, _} = node, :ok, allowed) when is_atom(mod) do
+  defp check_node({{:., _, [module, func]}, _, _} = node, :ok, allowed) when is_atom(module) do
     cond do
-      mod not in allowed ->
-        {node, {:error, "Module #{inspect(mod)} is not allowed"}}
+      module not in allowed ->
+        {node, {:error, "Module #{inspect(module)} is not allowed"}}
 
-      mod == :erlang and func in @forbidden_erlang_functions ->
+      module == :erlang and func in @forbidden_erlang_functions ->
         {node, {:error, ":erlang.#{func} is not allowed"}}
 
       true ->

--- a/lib/legion/source_registry.ex
+++ b/lib/legion/source_registry.ex
@@ -10,9 +10,9 @@ defmodule Legion.SourceRegistry do
 
   @extra_modules Application.compile_env(:legion, :extra_source_modules, [])
 
-  @sources Map.new(@extra_modules, fn mod ->
-             path = mod.__info__(:compile)[:source] |> to_string()
-             {mod, File.read!(path)}
+  @sources Map.new(@extra_modules, fn module ->
+             path = module.__info__(:compile)[:source] |> to_string()
+             {module, File.read!(path)}
            end)
 
   def sources, do: @sources

--- a/lib/legion/telemetry.ex
+++ b/lib/legion/telemetry.ex
@@ -182,12 +182,12 @@ defmodule Legion.Telemetry do
   end
 
   def handle_event([:legion, :agent, :message, :start], _measurements, meta, opts) do
-    msg =
+    message =
       if is_binary(meta.message),
         do: String.slice(meta.message, 0, 80),
         else: inspect(meta.message, limit: 5)
 
-    log(opts, meta, "message:start #{short(meta.agent)} #{inspect(msg)}")
+    log(opts, meta, "message:start #{short(meta.agent)} #{inspect(message)}")
   end
 
   def handle_event([:legion, :agent, :message, :stop], measurements, meta, opts) do
@@ -312,7 +312,8 @@ defmodule Legion.Telemetry do
     |> Enum.map_join("\n", &("      " <> &1))
   end
 
-  defp format_eval_error(%{message: msg}) when is_binary(msg), do: msg
+  defp format_eval_error(message) when is_binary(message), do: message
+  defp format_eval_error(%{message: message}) when is_binary(message), do: message
   defp format_eval_error(error) when is_exception(error), do: Exception.message(error)
   defp format_eval_error(error), do: inspect(error, pretty: true, limit: 50)
 end

--- a/lib/legion/tool.ex
+++ b/lib/legion/tool.ex
@@ -9,6 +9,10 @@ defmodule Legion.Tool do
 
     - `description/0` — override to return a hand-written summary **instead of**
       the source code. Defaults to the module's source code.
+    - `extra_allowed_modules/0` — override to return additional modules that the
+      sandbox should alias and permit when this tool is available. Defaults to `[]`.
+      Useful for tools like `Legion.Tools.AgentTool` that dispatch to other modules
+      the agent needs to reference by name.
 
   ## Example
 
@@ -32,6 +36,7 @@ defmodule Legion.Tool do
   """
 
   @callback description() :: String.t()
+  @callback extra_allowed_modules() :: [module()]
 
   defmacro __using__(_opts) do
     source = extract_module_source(File.read!(__CALLER__.file), __CALLER__.module)
@@ -40,8 +45,9 @@ defmodule Legion.Tool do
       @behaviour Legion.Tool
 
       def description, do: unquote(source)
+      def extra_allowed_modules, do: []
 
-      defoverridable description: 0
+      defoverridable description: 0, extra_allowed_modules: 0
     end
   end
 
@@ -54,9 +60,9 @@ defmodule Legion.Tool do
       nil ->
         raise "Could not find #{module_header} in source file"
 
-      start_idx ->
+      start_index ->
         lines
-        |> Enum.drop(start_idx)
+        |> Enum.drop(start_index)
         |> extract_do_end_block()
         |> Enum.join("\n")
     end

--- a/lib/legion/tools/agent_tool.ex
+++ b/lib/legion/tools/agent_tool.ex
@@ -9,21 +9,107 @@ defmodule Legion.Tools.AgentTool do
 
   Only listed agents can be invoked. Attempts to call unlisted agents raise an error.
 
-  ## Usage from agent code (executed in sandbox)
+  ## Usage example from agent code (executed in sandbox)
 
-      Legion.Tools.AgentTool.call(MyApp.WorkerAgent, "Summarize this data")
+      AgentTool.call(WorkerAgent, "Summarize this data")
+
+  Listed sub-agents are aliased into the sandbox automatically, so their short names
+  (the last segment of the module) resolve to the full module atom - no need to spell
+  out `MyApp.Agents.WorkerAgent`.
   """
 
   use Legion.Tool
 
   alias Legion.AgentServer
 
+  @impl Legion.Tool
+  def extra_allowed_modules, do: Vault.get(__MODULE__, [])[:agents] || []
+
+  @impl Legion.Tool
+  def description do
+    summaries =
+      case extra_allowed_modules() do
+        [] ->
+          "  (none configured - this tool will raise on any call)"
+
+        modules ->
+          Enum.map_join(modules, "\n", fn module ->
+            short = module |> Module.split() |> List.last()
+            "  - `#{short}` - #{moduledoc_summary(module)}"
+          end)
+      end
+
+    """
+    Delegate work to a specialized sub-agent. Each call runs a full sub-agent
+    turn, so fan out independent subtasks in parallel rather than sequentially.
+
+    ## Your sub-agents
+
+    #{summaries}
+
+    Call them by their short name (last module segment) - listed sub-agents
+    are auto-aliased in the sandbox.
+
+    ## One-shot call
+
+    `task` can be any Elixir term - string, map, keyword list, struct:
+
+        {:ok, result} =
+          AgentTool.call(SomeAgent, %{
+            key: value,
+            other_key: other_value
+          })
+
+    Returns:
+      - `{:ok, result}` - `result` matches the sub-agent's `output_schema`
+      - `{:cancel, reason}` - sub-agent hit its iteration/retry cap
+
+    ## Parallel fan-out
+
+    Use `AgentTool.parallel/1` for independent subtasks - each `call` blocks on
+    a full sub-agent run, so serial calls cost N turns; parallel costs ~1.
+
+        {:ok, picks} =
+          AgentTool.parallel(
+            for input <- inputs do
+              {SomeAgent, input}
+            end
+          )
+
+    Returns `{:ok, [result1, result2, ...]}` or the first `{:cancel, reason}`.
+
+    ## Sequential pipeline
+
+    `AgentTool.pipeline/1` threads each step's result into the next:
+
+        {:ok, final} =
+          AgentTool.pipeline([
+            {ResearchAgent, "find X"},
+            {WriterAgent, fn research -> "summarize: \#{research}" end}
+          ])
+    """
+  end
+
+  defp moduledoc_summary(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, %{"en" => doc}, _, _} when is_binary(doc) ->
+        doc
+        |> String.split("\n\n", parts: 2)
+        |> hd()
+        |> String.replace(~r/\s+/, " ")
+        |> String.trim()
+
+      _ ->
+        "(no @moduledoc)"
+    end
+  end
+
   @doc """
   Starts a long-lived sub-agent process and returns `{:ok, pid}`.
 
   Raises if the agent is not in the allowed list.
   """
-  def start_link(agent_module, task) when is_atom(agent_module) and is_binary(task) do
+  def start_link(agent_module, task) when is_atom(agent_module) do
     check_allowed!(agent_module)
 
     with {:ok, pid} <- AgentServer.start_link(agent_module) do
@@ -35,7 +121,7 @@ defmodule Legion.Tools.AgentTool do
   @doc """
   Sends a fire-and-forget message to a running agent pid.
   """
-  def cast(pid, message) when is_pid(pid) and is_binary(message) do
+  def cast(pid, message) when is_pid(pid) do
     AgentServer.cast(pid, message)
   end
 
@@ -47,13 +133,45 @@ defmodule Legion.Tools.AgentTool do
 
   When called with a pid, sends a message to the running agent and blocks for the reply.
   """
-  def call(agent_module, task) when is_atom(agent_module) and is_binary(task) do
+  def call(agent_module, task) when is_atom(agent_module) do
     check_allowed!(agent_module)
     Legion.execute(agent_module, task)
   end
 
-  def call(pid, message) when is_pid(pid) and is_binary(message) do
+  def call(pid, message) when is_pid(pid) do
     AgentServer.call(pid, message)
+  end
+
+  @doc """
+  Runs multiple sub-agent tasks in parallel and collects results.
+
+  Returns `{:ok, [result1, result2, ...]}` when every task succeeds, or the
+  first `{:cancel, reason}`. Raises if any agent is not in the allowed list.
+  """
+  def parallel(tasks, timeout \\ :infinity) when is_list(tasks) do
+    for {agent, _task} <- tasks, do: check_allowed!(agent)
+    Legion.parallel(tasks, timeout)
+  end
+
+  @doc """
+  Runs sub-agent tasks sequentially, threading each result to the next step.
+
+  Each step is `{agent, task_or_fn}`. If `task_or_fn` is a 1-arity function,
+  it receives the previous step's result and must return the task for the
+  next call. Halts early on the first `{:cancel, reason}`.
+  """
+  def pipeline(steps) when is_list(steps) do
+    for {agent, _} <- steps, do: check_allowed!(agent)
+    Legion.pipeline(steps)
+  end
+
+  @doc """
+  Chains a sub-agent call after a previous `{:ok, result}`. Passes
+  `{:cancel, reason}` through unchanged.
+  """
+  def then(prev, agent, fun) when is_function(fun, 1) do
+    check_allowed!(agent)
+    Legion.then(prev, agent, fun)
   end
 
   defp check_allowed!(agent_module) do

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Legion.MixProject do
     [
       app: :legion,
       version: @version,
-      elixir: "~> 1.19",
+      elixir: "~> 1.18",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),

--- a/test/integration/image_test.exs
+++ b/test/integration/image_test.exs
@@ -6,7 +6,7 @@ defmodule Legion.Integration.ImageTest do
 
       mix test test/integration/image_test.exs --include integration
   """
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias ReqLLM.Message.ContentPart
 
@@ -25,21 +25,38 @@ defmodule Legion.Integration.ImageTest do
     :ok
   end
 
-  test "describes an image sent as binary data" do
-    # 1x1 red pixel PNG
-    red_pixel_png =
-      Base.decode64!(
-        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
-      )
+  # 1x1 red pixel PNG
+  @red_pixel_base64 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC"
 
-    msg =
+  test "describes an image sent as binary data" do
+    red_pixel_png = Base.decode64!(@red_pixel_base64)
+
+    message =
       {:multipart,
        [
          ContentPart.text("Describe what you see in this image in one sentence."),
          ContentPart.image(red_pixel_png, "image/png")
        ]}
 
-    {:ok, result} = Legion.execute(ImageAgent, msg)
+    {:ok, result} = Legion.execute(ImageAgent, message)
+
+    assert is_binary(result)
+    assert String.downcase(result) =~ "red"
+  end
+
+  test "describes an image sent via {:image, data, media_type} shorthand" do
+    red_pixel_png = Base.decode64!(@red_pixel_base64)
+
+    {:ok, result} = Legion.execute(ImageAgent, {:image, red_pixel_png, "image/png"})
+
+    assert is_binary(result)
+    assert String.downcase(result) =~ "red"
+  end
+
+  test "describes an image sent via {:image_url, url} shorthand" do
+    data_url = "data:image/png;base64,#{@red_pixel_base64}"
+
+    {:ok, result} = Legion.execute(ImageAgent, {:image_url, data_url})
 
     assert is_binary(result)
     assert String.downcase(result) =~ "red"

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -7,11 +7,11 @@ defmodule Legion.AgentServerTest do
   alias Legion.Test.Support.MathAgent
   alias ReqLLM.Message.ContentPart
 
-  defmodule IsolatedBindingsAgent do
-    @moduledoc "Agent without shared bindings."
+  defmodule ConversationBindingsAgent do
+    @moduledoc "Agent with bindings persisted across the whole conversation."
     use Legion.Agent
 
-    def config, do: %{share_bindings: false}
+    def config, do: %{binding_scope: :conversation}
   end
 
   defmodule ConfiguredAgent do
@@ -139,31 +139,88 @@ defmodule Legion.AgentServerTest do
     end
   end
 
-  describe "image messages" do
-    test "sends {:image, data, media_type} as a content parts list to the LLM" do
-      test_pid = self()
-      image_data = <<0xFF, 0xD8, 0xFF, 0xE0>>
+  defp capture_user_content(test_pid) do
+    stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
+      user_msg = Enum.find(messages, &(&1[:role] == "user"))
+      send(test_pid, {:user_content, user_msg[:content]})
+      llm_response("ok")
+    end)
+  end
 
-      stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
-        user_msg = Enum.find(messages, &(&1[:role] == "user"))
-        send(test_pid, {:user_content, user_msg[:content]})
-        llm_response("ok")
-      end)
+  describe "multipart messages" do
+    test "passes a text + image part list through to the LLM unchanged" do
+      capture_user_content(self())
 
-      assert {:ok, "ok"} = Legion.execute(MathAgent, {:image, image_data, "image/jpeg"})
+      parts = [
+        ContentPart.text("Describe this image."),
+        ContentPart.image(<<1, 2, 3>>, "image/png")
+      ]
 
-      assert_received {:user_content, content}
-
-      assert [
-               %ContentPart{
-                 type: :image,
-                 media_type: "image/jpeg",
-                 data: ^image_data
-               }
-             ] = content
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:multipart, parts})
+      assert_received {:user_content, ^parts}
     end
 
-    test "sends {:image_url, url} as a content parts list to the LLM" do
+    test "supports text + image_url parts" do
+      capture_user_content(self())
+
+      parts = [
+        ContentPart.text("What is in this picture?"),
+        ContentPart.image_url("https://example.com/photo.png")
+      ]
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:multipart, parts})
+      assert_received {:user_content, ^parts}
+    end
+
+    test "supports a text-only part list" do
+      capture_user_content(self())
+
+      parts = [ContentPart.text("hello")]
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:multipart, parts})
+      assert_received {:user_content, ^parts}
+    end
+
+    test "supports an empty parts list" do
+      capture_user_content(self())
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:multipart, []})
+      assert_received {:user_content, []}
+    end
+  end
+
+  describe "image shorthand messages" do
+    test "wraps {:image, data, media_type} into a single image ContentPart" do
+      capture_user_content(self())
+
+      data = <<1, 2, 3>>
+      expected = [ContentPart.image(data, "image/png")]
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:image, data, "image/png"})
+      assert_received {:user_content, ^expected}
+    end
+
+    test "wraps {:image_url, url} into a single image_url ContentPart" do
+      capture_user_content(self())
+
+      url = "https://example.com/photo.png"
+      expected = [ContentPart.image_url(url)]
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, {:image_url, url})
+      assert_received {:user_content, ^expected}
+    end
+  end
+
+  describe "struct messages" do
+    defmodule SampleStruct do
+      defstruct [:id, :name]
+    end
+
+    defmodule EctoLikeStruct do
+      defstruct [:id, :name, :__meta__]
+    end
+
+    test "drops __struct__ and JSON-encodes the remaining fields" do
       test_pid = self()
 
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
@@ -173,21 +230,14 @@ defmodule Legion.AgentServerTest do
       end)
 
       assert {:ok, "ok"} =
-               Legion.execute(MathAgent, {:image_url, "https://example.com/photo.png"})
+               Legion.execute(MathAgent, %SampleStruct{id: 7, name: "ada"})
 
-      assert_received {:user_content, content}
-
-      assert [%ContentPart{type: :image_url, url: "https://example.com/photo.png"}] =
-               content
+      assert_received {:user_content, json}
+      assert Jason.decode!(json) == %{"id" => 7, "name" => "ada"}
     end
 
-    test "sends {:multipart, parts} as-is to the LLM" do
+    test "drops __meta__ before encoding (Ecto-style structs)" do
       test_pid = self()
-
-      parts = [
-        ContentPart.text("Describe this image."),
-        ContentPart.image(<<1, 2, 3>>, "image/png")
-      ]
 
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
         user_msg = Enum.find(messages, &(&1[:role] == "user"))
@@ -195,9 +245,99 @@ defmodule Legion.AgentServerTest do
         llm_response("ok")
       end)
 
-      assert {:ok, "ok"} = Legion.execute(MathAgent, {:multipart, parts})
+      msg = %EctoLikeStruct{id: 1, name: "x", __meta__: %{source: "users"}}
+
+      assert {:ok, "ok"} = Legion.execute(MathAgent, msg)
+
+      assert_received {:user_content, json}
+      assert Jason.decode!(json) == %{"id" => 1, "name" => "x"}
+    end
+  end
+
+  describe "max_message_length" do
+    test "truncates binary user input longer than the limit" do
+      capture_user_content(self())
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 100)
+      {:ok, _} = Legion.call(pid, String.duplicate("a", 5_000))
+
+      assert_received {:user_content, content}
+      assert String.starts_with?(content, String.duplicate("a", 100))
+      assert content =~ "[... truncated 4900 bytes ...]"
+    end
+
+    test "passes binary user input shorter than the limit through unchanged" do
+      capture_user_content(self())
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 100)
+      {:ok, _} = Legion.call(pid, "hello")
+
+      assert_received {:user_content, "hello"}
+    end
+
+    test "does not touch multipart content even when parts are large" do
+      capture_user_content(self())
+
+      parts = [ContentPart.text(String.duplicate("a", 5_000))]
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 100)
+      {:ok, _} = Legion.call(pid, {:multipart, parts})
 
       assert_received {:user_content, ^parts}
+    end
+
+    test ":infinity disables truncation" do
+      capture_user_content(self())
+
+      big = String.duplicate("a", 5_000)
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: :infinity)
+      {:ok, _} = Legion.call(pid, big)
+
+      assert_received {:user_content, ^big}
+    end
+
+    test "nil raises ArgumentError" do
+      assert_raise ArgumentError,
+                   ~r/expected :max_message_length to be a positive integer or :infinity/,
+                   fn ->
+                     Legion.start_link(MathAgent, max_message_length: nil)
+                   end
+    end
+
+    test "zero raises ArgumentError" do
+      assert_raise ArgumentError,
+                   ~r/expected :max_message_length to be a positive integer or :infinity/,
+                   fn ->
+                     Legion.start_link(MathAgent, max_message_length: 0)
+                   end
+    end
+
+    test "per-agent config overrides application config" do
+      Application.put_env(:legion, :config, %{max_message_length: 10})
+      on_exit(fn -> Application.delete_env(:legion, :config) end)
+
+      capture_user_content(self())
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 1_000)
+      {:ok, _} = Legion.call(pid, String.duplicate("a", 50))
+
+      assert_received {:user_content, content}
+      assert byte_size(content) == 50
+    end
+
+    test "application config applies when no per-agent override is given" do
+      Application.put_env(:legion, :config, %{max_message_length: 10})
+      on_exit(fn -> Application.delete_env(:legion, :config) end)
+
+      capture_user_content(self())
+
+      {:ok, pid} = Legion.start_link(MathAgent)
+      {:ok, _} = Legion.call(pid, String.duplicate("a", 50))
+
+      assert_received {:user_content, content}
+      assert String.starts_with?(content, String.duplicate("a", 10))
+      assert content =~ "[... truncated 40 bytes ...]"
     end
   end
 
@@ -233,8 +373,8 @@ defmodule Legion.AgentServerTest do
     end
   end
 
-  describe "share_bindings" do
-    test "bindings persist across turns by default" do
+  describe "binding_scope" do
+    test "bindings do not persist across turns by default (:turn)" do
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
@@ -247,10 +387,13 @@ defmodule Legion.AgentServerTest do
 
       {:ok, pid} = Legion.start_link(MathAgent)
       {:ok, 42} = Legion.call(pid, "set x")
-      assert {:ok, 43} = Legion.call(pid, "use x")
+
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert {:cancel, :reached_max_retries} = Legion.call(pid, "use x")
+      end)
     end
 
-    test "bindings do not persist across turns when share_bindings is false" do
+    test "bindings persist across turns with :conversation" do
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
@@ -261,12 +404,9 @@ defmodule Legion.AgentServerTest do
         end
       end)
 
-      {:ok, pid} = Legion.start_link(IsolatedBindingsAgent)
+      {:ok, pid} = Legion.start_link(ConversationBindingsAgent)
       {:ok, 42} = Legion.call(pid, "set x")
-
-      ExUnit.CaptureIO.capture_io(:stderr, fn ->
-        assert {:cancel, :reached_max_retries} = Legion.call(pid, "use x")
-      end)
+      assert {:ok, 43} = Legion.call(pid, "use x")
     end
   end
 end

--- a/test/legion/executor_test.exs
+++ b/test/legion/executor_test.exs
@@ -195,6 +195,75 @@ defmodule Legion.ExecutorTest do
     end
   end
 
+  describe "max_message_length in result/error feedback" do
+    test "truncates large code execution results in the feedback message" do
+      test_pid = self()
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+
+      stub(ReqLLM, :generate_object, fn _m, messages, _s ->
+        i = Agent.get_and_update(counter, fn n -> {n, n + 1} end)
+
+        if i > 0 do
+          last_msg = messages |> List.last() |> Map.get(:content)
+          send(test_pid, {:result_msg, last_msg})
+        end
+
+        case i do
+          0 ->
+            response(%{
+              "action" => "eval_and_continue",
+              "code" => "String.duplicate(\"a\", 5000)",
+              "result" => ""
+            })
+
+          1 ->
+            response(%{"action" => "return", "code" => "", "result" => "done"})
+        end
+      end)
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 200)
+      assert {:ok, "done"} = Legion.call(pid, "generate a lot")
+
+      assert_received {:result_msg, msg}
+      assert msg =~ "[... truncated"
+      assert byte_size(msg) < 1_000
+    end
+
+    test "truncates long error text in the retry feedback message" do
+      test_pid = self()
+      {:ok, counter} = Agent.start_link(fn -> 0 end)
+      long_message = String.duplicate("x", 5_000)
+
+      stub(ReqLLM, :generate_object, fn _m, messages, _s ->
+        i = Agent.get_and_update(counter, fn n -> {n, n + 1} end)
+
+        if i > 0 do
+          last_msg = messages |> List.last() |> Map.get(:content)
+          send(test_pid, {:error_msg, last_msg})
+        end
+
+        case i do
+          0 ->
+            response(%{
+              "action" => "eval_and_complete",
+              "code" => "raise \"#{long_message}\"",
+              "result" => ""
+            })
+
+          _ ->
+            response(%{"action" => "return", "code" => "", "result" => "recovered"})
+        end
+      end)
+
+      {:ok, pid} = Legion.start_link(MathAgent, max_message_length: 200)
+      assert {:ok, "recovered"} = Legion.call(pid, "fail loudly")
+
+      assert_received {:error_msg, msg}
+      assert msg =~ "[... truncated"
+      assert byte_size(msg) < 1_000
+    end
+  end
+
   describe "custom output_schema" do
     test "schema is passed to LLM with additionalProperties injected" do
       test_pid = self()

--- a/test/legion/sandbox/ast_checker_test.exs
+++ b/test/legion/sandbox/ast_checker_test.exs
@@ -216,6 +216,16 @@ defmodule Legion.Sandbox.ASTCheckerTest do
     assert msg =~ "__ENV__"
   end
 
+  test "def is forbidden" do
+    assert {:error, msg} = ASTChecker.check("def foo(x), do: x + 1", [])
+    assert msg =~ "def"
+  end
+
+  test "defp is forbidden" do
+    assert {:error, msg} = ASTChecker.check("defp foo(x), do: x + 1", [])
+    assert msg =~ "defp"
+  end
+
   # --- Edge cases ---
 
   test "syntax error returns parse error" do

--- a/test/legion/sandbox_test.exs
+++ b/test/legion/sandbox_test.exs
@@ -26,4 +26,25 @@ defmodule Legion.SandboxTest do
   test "exit returns an error tuple instead of crashing" do
     assert {:error, {:exit, :boom}} = Legion.Sandbox.execute("exit(:boom)", 15_000)
   end
+
+  test "compile error surfaces diagnostics instead of the generic wrapper message" do
+    code = ~S|x = 1
+"track: #{t.track}"|
+
+    assert {:error, msg} = Legion.Sandbox.execute(code, 15_000)
+    assert is_binary(msg)
+    assert msg =~ "undefined variable"
+    assert msg =~ "\"t\""
+    refute msg =~ "cannot compile file"
+  end
+
+  test "runtime exception is returned as the original struct" do
+    assert {:error, %RuntimeError{message: "boom"}} =
+             Legion.Sandbox.execute(~S|raise "boom"|, 15_000)
+  end
+
+  test "Calendar module is callable from sandboxed code" do
+    code = ~S|Calendar.strftime(~D[2026-04-17], "%Y-%m-%d")|
+    assert {:ok, {"2026-04-17", _}} = Legion.Sandbox.execute(code, 15_000)
+  end
 end


### PR DESCRIPTION
# Redesign binding scope, expand AgentTool, surface sandbox diagnostics

## Configuration

- Replace `share_bindings: boolean` with `binding_scope: :iteration | :turn | :conversation`. The old `false` default reset bindings mid-turn, which was surprising when an `eval_and_continue` step could not see its own earlier variables. New default is `:turn` - bindings persist across iterations within one turn but reset between turns. `:iteration` matches the old reset-every-eval behaviour; `:conversation` matches the old `share_bindings: true`.
- Add `max_message_length` (default `20_000`, `nil` disables). `Executor.truncate_content/2` is applied to user messages in `AgentServer.handle_message`, the inspected result in `format_result/3`, and the error text in `handle_failed_eval`. A stray large payload (scraped HTML, file dump) no longer blows up the context; truncation is marked with `[... truncated N bytes ...]` so the LLM knows the cut happened.
- Alphabetize `@known_config_keys` in `AgentServer` now that the list has grown.

## `AgentServer`

- Make `handle_message/2` public and document the accepted shapes: binary, `{:image, data, media_type}`, `{:image_url, url}`, `{:multipart, parts}`, struct (drops `__struct__`/`__meta__` then JSON-encodes), bare map or list (JSON-encoded), with `inspect/2` as a lossy fallback. Previously everything non-binary fell straight through to `inspect`, which is hard for the LLM to consume.
- Demote the module `@moduledoc` to `@moduledoc false` (internal; the public surface is `Legion`).

## `Executor`

- Rework `@action_descriptions` so `return` actively warns against using it to bail out of eval errors ("fix the code and re-run instead"). LLMs were abusing `return` to escape failing code loops.
- `format_result/2` becomes `format_result/3` taking `config` so it can truncate the inspected result.
- After a successful eval, zero `new_bindings` when `config.binding_scope == :iteration` - this is where `:iteration` scope is enforced.
- Include `tool.extra_allowed_modules()` in the sandbox allow-list (see AgentTool below).
- Add a `binary` head to `format_error/1` so raw string errors no longer fall through to `inspect/2`.

## `Sandbox`

- Wrap `Code.eval_string/2` in `Code.with_diagnostics/1`. On `{:error, %CompileError{}}` with non-empty diagnostics, replace the opaque "cannot compile file" error with the formatted diagnostics (e.g. `2:9: undefined variable "t"`). Runtime exceptions, throws, and exits pass through unchanged.
- Add `attach_diagnostics/2`, `format_diagnostics/1`, `format_position/1` helpers.

## `Sandbox.AstChecker`

- Add `def` and `defp` to `@forbidden_forms` - prevent agents from defining functions inside sandboxed code, which could shadow safe names or smuggle in arbitrary logic.
- Add `Calendar` to `@builtin_allowed` so `Calendar.strftime/2` works out of the box.
- Update the moduledoc to reflect the three-category model and the new safe list.

## `Legion.Tool`

- Add optional `extra_allowed_modules/0` callback (defaults to `[]`). Lets a tool declare extra modules that should be aliased and permitted in the sandbox when the tool is active - useful for tools that dispatch by module name and need the agent to reference those modules by their short name.

## `AgentTool`

- Implement `extra_allowed_modules/0` to return all configured sub-agents from Vault, so each sub-agent is auto-aliased in the sandbox (`AgentTool.call(WorkerAgent, ...)` works without the full module path).
- Override `description/0` to render a live directory: bulleted list of each configured sub-agent's short name and first-paragraph `@moduledoc`, plus usage examples.
- Add `parallel/2`, `pipeline/1`, `then/3` pass-throughs to `Legion.parallel/pipeline/then` that first `check_allowed!/1` every referenced agent. Agents can now orchestrate sub-agents without re-implementing the allow-list check. `parallel` fans out independent subtasks; `pipeline` threads each result into the next, halting on `{:cancel, _}`; `then` chains a single follow-up call.
- Drop the `is_binary(task)` / `is_binary(message)` guards on `start_link/2`, `cast/2`, and both `call/2` clauses so sub-agent inputs can be any term - matches the broader message-shape support in `AgentServer`.

## Prompt builder

- Tool descriptions now emit as `{short_name, content}` tuples and render as `### ShortName` sections with fenced code blocks (language inferred from whether the content starts with `defmodule`). The preamble tells the LLM that each tool is aliased to its short name in the sandbox. Non-Elixir descriptions embed cleanly.
- Conditionally render the binding-lifetime paragraph based on `binding_scope`: `:iteration` says bindings do not persist; `:turn` says they persist within a turn but reset between turns; `:conversation` adds that they persist across turns too.

## Error formatting

- Give `format_eval_error/1` a bare-binary head so plain-string errors no longer fall through to `inspect/2` (parallels the Executor change).
- Rename `msg` to `message` per the no-abbreviations style.

## Tests

- `agent_server_test.exs`: switch to `binding_scope: :conversation`; broaden multipart coverage (text+image, text+image_url, text-only, empty); add struct encoding (drops `__struct__`/`__meta__`); add `max_message_length` truncation (per-agent override, app-config fallback, `nil` disables, multipart untouched).
- `executor_test.exs`: verify `max_message_length` truncates large `eval_and_continue` result payloads and long error text in retry feedback.
- `sandbox_test.exs`: compile error surfaces diagnostics (asserts `undefined variable`, `"t"`, and absence of `"cannot compile file"`); runtime exceptions preserved as the original struct; `Calendar.strftime/2` callable from sandboxed code.
- `sandbox/ast_checker_test.exs`: `def` and `defp` are forbidden.
- `integration/image_test.exs`: switch to `async: true`, extract the red-pixel base64 to a module attribute, cover `{:image, data, media_type}` and `{:image_url, url}` shorthand input shapes end-to-end.

## Misc

- `mix.exs`: relax Elixir floor from `~> 1.19` to `~> 1.18` to broaden compatibility.
- `.github/workflows/ci.yml`: drop the `pull_request:` trigger (push-only) to avoid duplicate CI runs on same-repo PR branches.
- Rename single-letter / abbreviated locals (`mod` to `module`, `msg` to `message`, `err` to `error`, `start_idx` to `start_index`, `var_names` to `variable_names`) per the no-abbreviations style. Pure cosmetic.
- README: rewrite the feature bullet and configuration table around `binding_scope` and `max_message_length`; add a "Third-Party Modules as Tools" section documenting `extra_source_modules` and when to prefer a thin `use Legion.Tool` facade with a hand-written `description/0` (subset, size, clarity); add `@moduledoc` to example agents and clarify that `system_prompt/0` replaces the auto-generated prompt.
