### PR TITLE
Add sandbox resource limits and eval guards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@
 
 <!-- MDOC -->
 
-An Elixir framework for AI agents that live inside your application and act by writing code.
+An Elixir framework for AI agents that live inside your application and get things done by writing code.
 
-Legion is a runtime, not a coding assistant. No human reads, reviews, or commits the code its agents write. An agent writes Elixir the way you would write a shell one-liner: to do something, right now. Given a task, it reads your tools' source, writes a snippet that fetches, filters, decides, and acts, executes it, observes the result, and continues - all inside your running application.
+Give an agent a task and it doesn't pick from a menu of tool calls. It reads the source of the modules you expose to it, writes a snippet that does the job, and runs it right there in your app. Then it looks at the result and writes the next one. That's the whole loop.
 
-That single move replaces function calling. A traditional agent pays an LLM round-trip for every tool call: fetch, wait, decide, call the next one. A Legion agent collapses that loop into one evaluation, with pipelines, pattern matching, and the standard library at its disposal. Fewer LLM calls, lower latency, smarter behavior. [Why code execution beats function calling.](https://www.anthropic.com/engineering/code-execution-with-mcp)
+The code it writes is disposable, like a shell one-liner: made to do one thing, right now, then thrown away. No human reads it, reviews it, or commits it. Legion is a runtime, not a coding assistant.
 
-The whole framework fits in three ideas:
+Why bother? Because function calling is expensive. A traditional agent pays an LLM round trip for every step: fetch, wait, look, call the next tool, wait again. A Legion agent does all of it in one evaluation, with pipelines, pattern matching, and the standard library at its disposal. Fewer round trips, fewer tokens, smarter behavior. [Anthropic has the numbers on why code execution beats function calling.](https://www.anthropic.com/engineering/code-execution-with-mcp)
+
+Everything else is three ideas:
 
 - **Tools are plain Elixir modules.** The LLM reads their source directly - no schemas, no wrappers, no glue.
 - **Agents are BEAM processes.** Supervise them, pool them, `call` and `cast` them like GenServers.

--- a/README.md
+++ b/README.md
@@ -7,15 +7,13 @@
 
 <!-- MDOC -->
 
-An Elixir framework for AI agents that live inside your application and get things done by writing code.
+An Elixir framework for AI agents that live inside your application and act by writing code.
 
-Give an agent a task and it doesn't pick from a menu of tool calls. It reads the source of the modules you expose to it, writes a snippet that does the job, and runs it right there in your app. Then it looks at the result and writes the next one. That's the whole loop.
+Legion is a runtime, not a coding assistant. No human reads, reviews, or commits the code its agents write. An agent writes Elixir the way you would write a shell one-liner: to do something, right now. Given a task, it reads your tools' source, writes a snippet that fetches, filters, decides, and acts, executes it, observes the result, and continues - all inside your running application.
 
-The code it writes is disposable, like a shell one-liner: made to do one thing, right now, then thrown away. No human reads it, reviews it, or commits it. Legion is a runtime, not a coding assistant.
+That single move replaces function calling. A traditional agent pays an LLM round-trip for every tool call: fetch, wait, decide, call the next one. A Legion agent collapses that loop into one evaluation, with pipelines, pattern matching, and the standard library at its disposal. Fewer LLM calls, lower latency, smarter behavior. [Why code execution beats function calling.](https://www.anthropic.com/engineering/code-execution-with-mcp)
 
-Why bother? Because function calling is expensive. A traditional agent pays an LLM round trip for every step: fetch, wait, look, call the next tool, wait again. A Legion agent does all of it in one evaluation, with pipelines, pattern matching, and the standard library at its disposal. Fewer round trips, fewer tokens, smarter behavior. [Anthropic has the numbers on why code execution beats function calling.](https://www.anthropic.com/engineering/code-execution-with-mcp)
-
-Everything else is three ideas:
+The whole framework fits in three ideas:
 
 - **Tools are plain Elixir modules.** The LLM reads their source directly - no schemas, no wrappers, no glue.
 - **Agents are BEAM processes.** Supervise them, pool them, `call` and `cast` them like GenServers.

--- a/lib/legion/agent.ex
+++ b/lib/legion/agent.ex
@@ -41,9 +41,12 @@ defmodule Legion.Agent do
       - `max_iterations` — max successful execution steps per turn (default: `10`)
       - `max_retries` — max consecutive failures before giving up (default: `3`)
       - `sandbox_timeout` — timeout in ms for code execution (default: `60_000`)
-      - `sandbox_max_heap` — max heap in bytes for the process evaluating generated
-        code; the VM kills the eval when it exceeds the budget. Also covers tool code
-        called inline from the eval. Set `:infinity` to disable (default: `256_000_000`)
+      - `sandbox_max_heap` — memory budget in bytes for the process evaluating
+        generated code. The VM kills the eval when its heap and stack exceed the
+        budget; the binaries it references are polled separately (~50ms granularity)
+        because they live off-heap, so an eval can briefly hold up to twice the
+        budget. Also covers tool code called inline from the eval. Set `:infinity`
+        to disable (default: `256_000_000`)
       - `eval_guard` — a `Legion.EvalGuard` module that vets generated code before
         it runs, for policy the sandbox cannot express. Runs on the critical path;
         a denial reaches the agent as an execution error (default: `nil`, no guard)
@@ -51,6 +54,11 @@ defmodule Legion.Agent do
         enforced by polling (~50ms granularity), so an eval that computes hard gets
         killed even while the wall clock is fine with it. Counts tool code called
         inline from the eval too. Set `:infinity` to disable (default: `:infinity`)
+      - `sandbox_priority` — scheduler priority of the eval process, and so of any
+        tool code it calls inline. The default keeps generated code from crowding
+        out the rest of the node, at the cost of it taking longer under load -
+        raise it to `:normal` if evals are hitting `sandbox_timeout` on a busy
+        system (default: `:low`)
       - `binding_scope` — how long variable bindings from code execution live
         (default: `:turn`):
         - `:iteration` — bindings reset between every code execution

--- a/lib/legion/agent.ex
+++ b/lib/legion/agent.ex
@@ -41,6 +41,16 @@ defmodule Legion.Agent do
       - `max_iterations` — max successful execution steps per turn (default: `10`)
       - `max_retries` — max consecutive failures before giving up (default: `3`)
       - `sandbox_timeout` — timeout in ms for code execution (default: `60_000`)
+      - `sandbox_max_heap` — max heap in bytes for the process evaluating generated
+        code; the VM kills the eval when it exceeds the budget. Also covers tool code
+        called inline from the eval. Set `:infinity` to disable (default: `256_000_000`)
+      - `eval_guard` — a `Legion.EvalGuard` module that vets generated code before
+        it runs, for policy the sandbox cannot express. Runs on the critical path;
+        a denial reaches the agent as an execution error (default: `nil`, no guard)
+      - `sandbox_max_reductions` — CPU budget in reductions for the eval process,
+        enforced by polling (~50ms granularity), so an eval that computes hard gets
+        killed even while the wall clock is fine with it. Counts tool code called
+        inline from the eval too. Set `:infinity` to disable (default: `:infinity`)
       - `binding_scope` — how long variable bindings from code execution live
         (default: `:turn`):
         - `:iteration` — bindings reset between every code execution

--- a/lib/legion/agent_prompt.ex
+++ b/lib/legion/agent_prompt.ex
@@ -25,6 +25,7 @@ defmodule Legion.AgentPrompt do
         description: description,
         tool_contents: tool_contents,
         action_types: agent.action_types(),
+        plain_text_result?: match?(%{"type" => "string"}, agent.output_schema()),
         elixir_version: System.version(),
         binding_scope: binding_scope
       )

--- a/lib/legion/agent_server.ex
+++ b/lib/legion/agent_server.ex
@@ -275,7 +275,7 @@ defmodule Legion.AgentServer do
     |> Executor.truncate_content(max_length)
   end
 
-  @known_config_keys ~w(binding_scope max_iterations max_message_length max_retries model sandbox_timeout)a
+  @known_config_keys ~w(binding_scope eval_guard max_iterations max_message_length max_retries model sandbox_max_heap sandbox_max_reductions sandbox_timeout)a
 
   defp resolve_config(agent_module, opts) do
     app_config = Application.get_env(:legion, :config, %{})

--- a/lib/legion/agent_server.ex
+++ b/lib/legion/agent_server.ex
@@ -275,7 +275,7 @@ defmodule Legion.AgentServer do
     |> Executor.truncate_content(max_length)
   end
 
-  @known_config_keys ~w(binding_scope eval_guard max_iterations max_message_length max_retries model sandbox_max_heap sandbox_max_reductions sandbox_timeout)a
+  @known_config_keys ~w(binding_scope eval_guard max_iterations max_message_length max_retries model sandbox_max_heap sandbox_max_reductions sandbox_priority sandbox_timeout)a
 
   defp resolve_config(agent_module, opts) do
     app_config = Application.get_env(:legion, :config, %{})

--- a/lib/legion/eval_guard.ex
+++ b/lib/legion/eval_guard.ex
@@ -1,0 +1,77 @@
+defmodule Legion.EvalGuard do
+  @moduledoc """
+  Last check before generated code runs.
+
+  A guard sees the code an agent wrote and decides whether the sandbox may
+  evaluate it. It runs after the AST checker has accepted the code and before
+  the eval process is spawned, so it is the place for policy the sandbox cannot
+  express: "never loop over checkout", "do not read another conversation's
+  cart", "no bulk export of the orders table".
+
+  Guards are off unless configured:
+
+      config :legion, :config, %{eval_guard: MyApp.CodeReview}
+
+  or per agent:
+
+      def config, do: %{eval_guard: MyApp.CodeReview}
+
+  ## The callback
+
+      defmodule MyApp.CodeReview do
+        @behaviour Legion.EvalGuard
+
+        @impl true
+        def check(code, _context) do
+          if String.contains?(code, "checkout") and String.contains?(code, "Enum.each") do
+            {:deny, "looping over checkout is not allowed - check out once"}
+          else
+            :allow
+          end
+        end
+      end
+
+  `context` carries `:agent`, `:agent_id`, and `:tools` (the modules the code
+  may call).
+
+  A `{:deny, reason}` verdict is handed to the agent as an execution error, so
+  it can rewrite the code or explain itself to the user - the same path a
+  runtime error takes. Make the reason something an LLM can act on.
+
+  ## Guards run on the critical path
+
+  Whatever a guard does, the agent waits for it. A guard that calls out to an
+  LLM adds that round trip to every iteration, and a guard that raises fails
+  the evaluation. To review code with a model without paying for it in
+  latency, judge *asynchronously*: return `:allow`, and have the guard spawn
+  the review, recording verdicts for an audit trail. Blocking on the model is
+  worth it only for code you would rather not run at all - and only once the
+  async verdicts have shown you what it actually flags.
+  """
+
+  alias Legion.Telemetry
+
+  @type context :: %{agent: module(), agent_id: term(), tools: [module()]}
+
+  @callback check(code :: String.t(), context :: context()) :: :allow | {:deny, String.t()}
+
+  @doc false
+  def check(nil, _code, _context), do: :allow
+
+  def check(guard, code, context) do
+    case guard.check(code, context) do
+      :allow ->
+        :allow
+
+      {:deny, reason} ->
+        Telemetry.emit([:legion, :eval_guard, :denied], %{}, %{
+          agent: context.agent,
+          guard: guard,
+          code: code,
+          reason: reason
+        })
+
+        {:deny, reason}
+    end
+  end
+end

--- a/lib/legion/eval_guard.ex
+++ b/lib/legion/eval_guard.ex
@@ -1,53 +1,59 @@
 defmodule Legion.EvalGuard do
   @moduledoc """
-  Last check before generated code runs.
+    Last check before generated code runs.
 
-  A guard sees the code an agent wrote and decides whether the sandbox may
-  evaluate it. It runs after the AST checker has accepted the code and before
-  the eval process is spawned, so it is the place for policy the sandbox cannot
-  express: "never loop over checkout", "do not read another conversation's
-  cart", "no bulk export of the orders table".
+    A guard sees the code an agent wrote and decides whether the sandbox may
+    evaluate it. It runs after the AST checker accepts the code and before the
+    eval process is spawned, so it is the place for policy the sandbox cannot
+    express: "never loop over checkout", "no bulk export of the orders table".
 
-  Guards are off unless configured:
+        defmodule MyApp.CodeReview do
+          @behaviour Legion.EvalGuard
 
-      config :legion, :config, %{eval_guard: MyApp.CodeReview}
-
-  or per agent:
-
-      def config, do: %{eval_guard: MyApp.CodeReview}
-
-  ## The callback
-
-      defmodule MyApp.CodeReview do
-        @behaviour Legion.EvalGuard
-
-        @impl true
-        def check(code, _context) do
-          if String.contains?(code, "checkout") and String.contains?(code, "Enum.each") do
-            {:deny, "looping over checkout is not allowed - check out once"}
-          else
-            :allow
+          @impl true
+          def check(code, _context) do
+            if String.contains?(code, "checkout") and String.contains?(code, "Enum.each") do
+              {:deny, "looping over checkout is not allowed - check out once"}
+            else
+              :allow
+            end
           end
         end
-      end
 
-  `context` carries `:agent`, `:agent_id`, and `:tools` (the modules the code
-  may call).
+    Guards are off unless configured, globally or per agent:
 
-  A `{:deny, reason}` verdict is handed to the agent as an execution error, so
-  it can rewrite the code or explain itself to the user - the same path a
-  runtime error takes. Make the reason something an LLM can act on.
+        config :legion, :config, %{eval_guard: MyApp.CodeReview}
 
-  ## Guards run on the critical path
+        def config, do: %{eval_guard: MyApp.CodeReview}
 
-  Whatever a guard does, the agent waits for it. A guard that calls out to an
-  LLM adds that round trip to every iteration, and a guard that raises fails
-  the evaluation. To review code with a model without paying for it in
-  latency, judge *asynchronously*: return `:allow`, and have the guard spawn
-  the review, recording verdicts for an audit trail. Blocking on the model is
-  worth it only for code you would rather not run at all - and only once the
-  async verdicts have shown you what it actually flags.
+    `context` carries `:agent`, `:agent_id`, and `:tools` (the modules the code
+    may call).
+
+    A `{:deny, reason}` reaches the agent as an execution error, the same path a
+    runtime error takes, so it can rewrite the code or explain itself to the
+    user. Make the reason something an LLM can act on.
+
+    `Legion.EvalGuard.LLM` writes the guard for you from a policy in plain
+    language:
+
+        defmodule MyApp.CodeReview do
+          use Legion.EvalGuard.LLM, policy: "Deny code that checks out more than once."
+        end
+
+    Guards run on the critical path - the agent waits for every one, so that
+    review costs a model round trip on every eval. Prefer returning `:allow`
+    and reviewing asynchronously until the async verdicts show blocking is
+    worth it.
+
+    A guard that raises, exits, or returns anything other than a verdict is
+    itself a denial - a safety boundary that stops working has to stop the code
+    with it. The `[:legion, :eval_guard, :denied]` event carries the failure as
+    its reason, so a broken guard shows up as every eval being refused. It is
+    also logged as a warning - nothing the agent does can fix it, so it needs a
+    reader who can.
   """
+
+  require Logger
 
   alias Legion.Telemetry
 
@@ -59,7 +65,7 @@ defmodule Legion.EvalGuard do
   def check(nil, _code, _context), do: :allow
 
   def check(guard, code, context) do
-    case guard.check(code, context) do
+    case verdict(guard, code, context) do
       :allow ->
         :allow
 
@@ -73,5 +79,26 @@ defmodule Legion.EvalGuard do
 
         {:deny, reason}
     end
+  end
+
+  defp verdict(guard, code, context) do
+    case guard.check(code, context) do
+      :allow -> :allow
+      {:deny, reason} -> {:deny, reason}
+      other -> broken(guard, "the guard returned #{inspect(other)} instead of a verdict")
+    end
+  rescue
+    exception -> broken(guard, "the guard raised #{Exception.message(exception)}")
+  catch
+    :throw, value -> broken(guard, "the guard threw #{inspect(value)}")
+    :exit, reason -> broken(guard, "the guard exited with #{inspect(reason)}")
+  end
+
+  # The agent only ever sees "your code was refused", and rewriting the code
+  # will not help - a broken guard is the host's bug and has to be visible as
+  # one, not as an agent that suddenly cannot run anything.
+  defp broken(guard, reason) do
+    Logger.error("#{inspect(guard)} failed to return a verdict, denying the eval: #{reason}")
+    {:deny, reason}
   end
 end

--- a/lib/legion/eval_guard/llm.ex
+++ b/lib/legion/eval_guard/llm.ex
@@ -1,0 +1,124 @@
+defmodule Legion.EvalGuard.LLM do
+  @moduledoc """
+  A `Legion.EvalGuard` that asks a model whether the code may run.
+
+  Define a guard with a policy written in plain language:
+
+      defmodule MyApp.CodeReview do
+        use Legion.EvalGuard.LLM,
+          policy: \"\"\"
+          Deny code that checks out more than once, exports the whole orders
+          table, or reads a cart that is not the current conversation's.
+          \"\"\"
+      end
+
+      def config, do: %{eval_guard: MyApp.CodeReview}
+
+  Options are `:policy` and `:model` (which defaults to the same model the
+  executor uses). The reviewing model sees the policy, the agent's name, the
+  tool modules the code may call, and the code itself - not the conversation.
+
+  Without a `:policy` the guard falls back to `default_policy/0`, which denies
+  code that goes after the host rather than the task - shelling out, touching
+  the filesystem or the network directly, reaching into other processes or the
+  runtime:
+
+      defmodule MyApp.HostGuard do
+        use Legion.EvalGuard.LLM
+      end
+
+  The sandbox already blocks the modules that do most of this, so the default
+  earns its keep against what an allowed tool can be talked into.
+
+  This is a blocking review: the agent waits for a second model round trip on
+  every eval. Read the latency note in `Legion.EvalGuard` before reaching for
+  it. If the review request fails, the code is denied, per the same module's
+  rule that a broken guard denies.
+  """
+
+  alias Legion.Executor
+
+  @default_policy """
+  Deny code that acts on the machine or the runtime instead of the task:
+
+  - running shell commands, spawning OS processes, or loading native code
+  - reading, writing or deleting files outside what a tool exposes
+  - opening its own network connections, or sending data to an address the
+    code itself chose
+  - reading credentials, environment variables, or application config
+  - reaching into other processes or nodes, killing them, or changing runtime
+    state (tracing, code loading, system flags)
+  - consuming the machine on purpose: unbounded recursion or loops, allocating
+    huge terms, sleeping for a long time
+
+  Allow ordinary work: arithmetic, data shuffling, and calls to the tool
+  modules the agent was given, including ones that happen to touch files or
+  the network on the agent's behalf.
+  """
+
+  @verdict_schema %{
+    "type" => "object",
+    "required" => ["verdict", "reason"],
+    "additionalProperties" => false,
+    "properties" => %{
+      "verdict" => %{"type" => "string", "enum" => ["allow", "deny"]},
+      "reason" => %{
+        "type" => "string",
+        "description" =>
+          "Why the code was denied, addressed to the agent that wrote it, so it can " <>
+            "write something acceptable instead. Empty string when allowing."
+      }
+    }
+  }
+
+  defmacro __using__(opts) do
+    quote do
+      @behaviour Legion.EvalGuard
+
+      @impl true
+      def check(code, context), do: unquote(__MODULE__).review(code, context, unquote(opts))
+
+      defoverridable check: 2
+    end
+  end
+
+  @doc """
+  The policy used when a guard does not give one: deny code that goes after the
+  host rather than the task.
+
+  Useful as a starting point for your own - `policy: default_policy() <> "..."`.
+  """
+  def default_policy, do: @default_policy
+
+  @doc false
+  def review(code, context, opts) do
+    model = Keyword.get(opts, :model, Executor.default_config().model)
+    policy = Keyword.get(opts, :policy, @default_policy)
+
+    messages = [
+      Executor.message(:system, system_prompt(policy, context)),
+      Executor.message(:user, code)
+    ]
+
+    case ReqLLM.generate_object(model, messages, @verdict_schema) do
+      {:ok, %{object: %{"verdict" => "allow"}}} -> :allow
+      {:ok, %{object: %{"verdict" => "deny", "reason" => reason}}} -> {:deny, reason}
+      {:ok, response} -> {:deny, "the review returned #{inspect(response)}"}
+      {:error, reason} -> {:deny, "the review request failed: #{inspect(reason)}"}
+    end
+  end
+
+  defp system_prompt(policy, context) do
+    """
+    You are reviewing Elixir code an AI agent wrote, before it runs in a sandbox.
+    Allow anything the policy does not forbid - you are the last check, not the
+    only one, and a wrongly denied eval costs the agent a turn.
+
+    Policy:
+    #{policy}
+
+    The code was written by #{inspect(context.agent)} and may call these modules:
+    #{Enum.map_join(context.tools, ", ", &inspect/1)}
+    """
+  end
+end

--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -10,14 +10,16 @@ defmodule Legion.Executor do
   """
 
   alias Legion.{EvalGuard, Sandbox, Telemetry}
+  alias Legion.Sandbox.ASTChecker
 
   @default_config %{
     model: "openai:gpt-5.4",
     max_iterations: 10,
     max_retries: 3,
     sandbox_timeout: 60_000,
-    sandbox_max_heap: 256_000_000,
+    sandbox_max_heap: Sandbox.default_max_heap(),
     sandbox_max_reductions: :infinity,
+    sandbox_priority: :low,
     eval_guard: nil,
     binding_scope: :turn,
     max_message_length: 20_000
@@ -290,19 +292,21 @@ defmodule Legion.Executor do
 
       sandbox_limits = [
         max_heap: config.sandbox_max_heap,
-        max_reductions: config.sandbox_max_reductions
+        max_reductions: config.sandbox_max_reductions,
+        priority: config.sandbox_priority
       ]
 
       guard_context = %{agent: agent_module, agent_id: Vault.get(:agent_id), tools: tools}
 
-      with :allow <- EvalGuard.check(config.eval_guard, code, guard_context),
+      with :ok <- ASTChecker.check(code, allowed),
+           :allow <- EvalGuard.check(config.eval_guard, code, guard_context),
            {:ok, {value, new_bindings}} <-
              Sandbox.execute(code, config.sandbox_timeout, allowed, bindings, sandbox_limits) do
         {{:ok, {value, new_bindings}}, %{success: true, result: value}}
       else
         {:deny, reason} ->
           error = "refused by #{inspect(config.eval_guard)}: #{reason}"
-          {{:error, error}, %{success: false, error: error, denied_by: config.eval_guard}}
+          {{:error, error}, %{success: false, error: error}}
 
         {:error, error} ->
           {{:error, error}, %{success: false, error: error}}

--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -9,13 +9,16 @@ defmodule Legion.Executor do
   context across turns.
   """
 
-  alias Legion.{Sandbox, Telemetry}
+  alias Legion.{EvalGuard, Sandbox, Telemetry}
 
   @default_config %{
     model: "openai:gpt-5.4",
     max_iterations: 10,
     max_retries: 3,
     sandbox_timeout: 60_000,
+    sandbox_max_heap: 256_000_000,
+    sandbox_max_reductions: :infinity,
+    eval_guard: nil,
     binding_scope: :turn,
     max_message_length: 20_000
   }
@@ -52,7 +55,7 @@ defmodule Legion.Executor do
     "eval_and_complete" =>
       "Finish the turn with the code's result. Use when the final answer comes from executing code.",
     "return" =>
-      "Finish the turn with a structured result and no code execution. Only use when the task is fully done - not to report in-progress work, ask the user something, or bail out of execution errors (fix the code and re-run instead). The result is a final answer, not a chat message: never return a status like \"starting\" or \"working on it\" - do the work first.",
+      "Finish the turn with a result and no code execution. Only use when the task is fully done - not to report in-progress work, ask the user something, or bail out of execution errors (fix the code and re-run instead). The result is a final answer, not a chat message: never return a status like \"starting\" or \"working on it\" - do the work first.",
     "done" =>
       "Finish the turn with no result to return. This ends your run - nothing executes after it, so only use it when everything you were asked to do is fully done. Never announce upcoming work and then pick this action; do the work first (eval_and_continue)."
   }
@@ -62,7 +65,7 @@ defmodule Legion.Executor do
 
     description =
       types
-      |> Enum.map_join("\n", fn t -> "- \"#{t}\": #{Map.fetch!(@action_descriptions, t)}" end)
+      |> Enum.map_join("\n", fn t -> "- \"#{t}\": #{action_description(t, agent_module)}" end)
 
     %{
       "type" => "object",
@@ -83,6 +86,21 @@ defmodule Legion.Executor do
       }
     }
   end
+
+  defp action_description("return", agent_module) do
+    if plain_text_output?(agent_module) do
+      "Finish the turn with your final answer and no code execution. The result is plain text shown to the user - never wrap it in JSON. " <>
+        "Only use when the task is fully done - not to report in-progress work, ask the user something, or bail out of execution errors (fix the code and re-run instead). " <>
+        "The result is a final answer, not a chat message: never return a status like \"starting\" or \"working on it\" - do the work first."
+    else
+      Map.fetch!(@action_descriptions, "return")
+    end
+  end
+
+  defp action_description(type, _agent_module), do: Map.fetch!(@action_descriptions, type)
+
+  defp plain_text_output?(agent_module),
+    do: match?(%{"type" => "string"}, agent_module.output_schema())
 
   # OpenAI strict mode requires `additionalProperties: false` on every object
   # in the schema tree. Inject it recursively so users don't have to.
@@ -270,9 +288,21 @@ defmodule Legion.Executor do
 
       allowed = tools ++ Enum.flat_map(tools, &extra_allowed_modules/1)
 
-      case Sandbox.execute(code, config.sandbox_timeout, allowed, bindings) do
-        {:ok, {value, new_bindings}} ->
-          {{:ok, {value, new_bindings}}, %{success: true, result: value}}
+      sandbox_limits = [
+        max_heap: config.sandbox_max_heap,
+        max_reductions: config.sandbox_max_reductions
+      ]
+
+      guard_context = %{agent: agent_module, agent_id: Vault.get(:agent_id), tools: tools}
+
+      with :allow <- EvalGuard.check(config.eval_guard, code, guard_context),
+           {:ok, {value, new_bindings}} <-
+             Sandbox.execute(code, config.sandbox_timeout, allowed, bindings, sandbox_limits) do
+        {{:ok, {value, new_bindings}}, %{success: true, result: value}}
+      else
+        {:deny, reason} ->
+          error = "refused by #{inspect(config.eval_guard)}: #{reason}"
+          {{:error, error}, %{success: false, error: error, denied_by: config.eval_guard}}
 
         {:error, error} ->
           {{:error, error}, %{success: false, error: error}}

--- a/lib/legion/prompts/system_prompt.eex
+++ b/lib/legion/prompts/system_prompt.eex
@@ -5,7 +5,7 @@ You are an AI agent that solves tasks by writing and executing Elixir <%= elixir
 For each step, you respond with a JSON object containing:
 - `action`: what to do — <%= Enum.map_join(action_types, ", ", fn t -> "`\"#{t}\"`" end) %>
 - `code`: Elixir code to execute (for `eval_*` actions)
-- `result`: structured result (for `"return"` action)
+- `result`: <%= if plain_text_result? do %>your final answer - plain text shown to the user, no JSON wrapping<% else %>structured result<% end %> (for `"return"` action)
 
 **Prefer writing code to accomplish your task.** Use the available tools by calling their functions in your code. Examine the tool source code below to understand what functions are available and how to use them.
 

--- a/lib/legion/sandbox.ex
+++ b/lib/legion/sandbox.ex
@@ -37,17 +37,24 @@ defmodule Legion.Sandbox do
   `allowed_modules` are aliased and made available to the evaluated code
   (on top of the built-in safe modules).
 
+  `limits` bound the resources of the evaluating process (each `:infinity` to
+  disable, the default):
+
+    - `:max_heap` — heap budget in bytes; the VM kills the eval on excess
+    - `:max_reductions` — CPU budget in reductions, enforced by polling
+
   Returns `{:ok, {result, new_bindings}}` on success, or `{:error, reason}` on
-  validation failure, runtime exception, crash, or timeout. The returned
-  `new_bindings` can be passed to subsequent calls to preserve variable scope.
+  validation failure, runtime exception, crash, timeout, or exceeded limit.
+  The returned `new_bindings` can be passed to subsequent calls to preserve
+  variable scope.
   """
-  def execute(code_string, timeout_ms, allowed_modules \\ [], bindings \\ [])
-      when is_binary(code_string) and is_list(allowed_modules) and
+  def execute(code_string, timeout_ms, allowed_modules \\ [], bindings \\ [], limits \\ [])
+      when is_binary(code_string) and is_list(allowed_modules) and is_list(limits) and
              (is_integer(timeout_ms) or timeout_ms == :infinity) do
     with :ok <- ASTChecker.check(code_string, allowed_modules) do
       code_string
       |> append_aliases(allowed_modules)
-      |> eval(timeout_ms, bindings)
+      |> eval(timeout_ms, bindings, limits)
     end
   end
 
@@ -61,11 +68,23 @@ defmodule Legion.Sandbox do
   end
 
   # sobelow_skip ["RCE.CodeModule"]
-  defp eval(code_string, timeout_ms, bindings) do
+  defp eval(code_string, timeout_ms, bindings, limits) do
     parent = self()
+    max_heap_bytes = Keyword.get(limits, :max_heap, :infinity)
+    max_reductions = Keyword.get(limits, :max_reductions, :infinity)
 
     {pid, ref} =
       spawn_monitor(fn ->
+        # Generated code must not starve the node (low priority) or OOM it
+        # (max_heap_size makes the VM kill this process at the budget).
+        # Both flags also cover tool code called inline from the eval.
+        Process.flag(:priority, :low)
+
+        if is_integer(max_heap_bytes) do
+          heap_words = div(max_heap_bytes, :erlang.system_info(:wordsize))
+          Process.flag(:max_heap_size, %{size: heap_words, kill: true, error_logger: false})
+        end
+
         {result, diagnostics} =
           Code.with_diagnostics(fn ->
             try do
@@ -82,18 +101,85 @@ defmodule Legion.Sandbox do
         send(parent, {:result, self(), attach_diagnostics(result, diagnostics)})
       end)
 
+    deadline =
+      if timeout_ms == :infinity,
+        do: :infinity,
+        else: System.monotonic_time(:millisecond) + timeout_ms
+
+    await_result(pid, ref, deadline, max_reductions, max_heap_bytes)
+  end
+
+  # How often the parent samples the eval's reduction counter. Only relevant
+  # when a :max_reductions limit is set - the budget can be overshot by up to
+  # one interval's worth of work.
+  @reduction_poll_interval_ms 50
+
+  defp await_result(pid, ref, deadline, max_reductions, max_heap_bytes) do
     receive do
       {:result, ^pid, result} ->
         Process.demonitor(ref, [:flush])
         result
 
+      # A :killed exit with a heap budget set is the VM enforcing it - nothing
+      # else brutally kills the eval while we still hold its monitor.
+      {:DOWN, ^ref, :process, _pid, :killed} when is_integer(max_heap_bytes) ->
+        {:error, "evaluation exceeded the memory limit and was killed"}
+
       {:DOWN, ^ref, :process, _pid, reason} ->
         {:error, {:process_crashed, reason}}
     after
-      timeout_ms ->
-        Process.demonitor(ref, [:flush])
-        Process.exit(pid, :kill)
-        {:error, :timeout}
+      wait_ms(deadline, max_reductions) ->
+        reductions = reductions_over_budget(pid, max_reductions)
+
+        cond do
+          deadline != :infinity and System.monotonic_time(:millisecond) >= deadline ->
+            kill(pid, ref)
+            {:error, :timeout}
+
+          reductions != nil ->
+            kill(pid, ref)
+
+            {:error,
+             "evaluation exceeded the reduction (CPU) limit after ~#{reductions} reductions and was killed"}
+
+          true ->
+            await_result(pid, ref, deadline, max_reductions, max_heap_bytes)
+        end
+    end
+  end
+
+  defp wait_ms(:infinity, :infinity), do: :infinity
+  defp wait_ms(deadline, :infinity), do: max(deadline - System.monotonic_time(:millisecond), 0)
+  defp wait_ms(:infinity, _max_reductions), do: @reduction_poll_interval_ms
+
+  defp wait_ms(deadline, _max_reductions) do
+    deadline
+    |> Kernel.-(System.monotonic_time(:millisecond))
+    |> max(0)
+    |> min(@reduction_poll_interval_ms)
+  end
+
+  defp reductions_over_budget(_pid, :infinity), do: nil
+
+  defp reductions_over_budget(pid, max_reductions) do
+    # nil process_info means the eval already exited - its final message is
+    # in our mailbox and the next receive picks it up.
+    case Process.info(pid, :reductions) do
+      {:reductions, reductions} when reductions > max_reductions -> reductions
+      _ -> nil
+    end
+  end
+
+  defp kill(pid, ref) do
+    Process.demonitor(ref, [:flush])
+    Process.exit(pid, :kill)
+
+    # The eval may have finished between the budget check and the kill -
+    # drop its stray result so it cannot leak into the caller's mailbox.
+    receive do
+      {:result, ^pid, _result} -> :ok
+    after
+      0 -> :ok
     end
   end
 

--- a/lib/legion/sandbox.ex
+++ b/lib/legion/sandbox.ex
@@ -30,6 +30,13 @@ defmodule Legion.Sandbox do
 
   alias Legion.Sandbox.ASTChecker
 
+  # Generated code runs with a memory budget whether or not the caller asked
+  # for one - unbounded is never the right default for code an LLM wrote.
+  @default_max_heap 256_000_000
+
+  @doc false
+  def default_max_heap, do: @default_max_heap
+
   @doc """
   Evaluates `code_string` in a sandboxed process.
 
@@ -37,11 +44,16 @@ defmodule Legion.Sandbox do
   `allowed_modules` are aliased and made available to the evaluated code
   (on top of the built-in safe modules).
 
-  `limits` bound the resources of the evaluating process (each `:infinity` to
-  disable, the default):
+  `limits` bound what the evaluating process may take from the node:
 
-    - `:max_heap` — heap budget in bytes; the VM kills the eval on excess
-    - `:max_reductions` — CPU budget in reductions, enforced by polling
+    - `:max_heap` — memory budget in bytes, applied twice: the VM kills the eval
+      when its heap and stack exceed it, and the parent kills it when the
+      binaries it references do (those live off-heap, so the VM flag misses them).
+      Set `:infinity` to disable (default: `#{@default_max_heap}`)
+    - `:max_reductions` — CPU budget in reductions, enforced by polling. Set
+      `:infinity` to disable (default: `:infinity`)
+    - `:priority` — scheduler priority for the eval, any value `Process.flag/2`
+      accepts (default: `:low`, so generated code yields to the rest of the node)
 
   Returns `{:ok, {result, new_bindings}}` on success, or `{:error, reason}` on
   validation failure, runtime exception, crash, timeout, or exceeded limit.
@@ -70,18 +82,24 @@ defmodule Legion.Sandbox do
   # sobelow_skip ["RCE.CodeModule"]
   defp eval(code_string, timeout_ms, bindings, limits) do
     parent = self()
-    max_heap_bytes = Keyword.get(limits, :max_heap, :infinity)
+    max_heap_bytes = Keyword.get(limits, :max_heap, @default_max_heap)
     max_reductions = Keyword.get(limits, :max_reductions, :infinity)
+    priority = Keyword.get(limits, :priority, :low)
 
     {pid, ref} =
       spawn_monitor(fn ->
-        # Generated code must not starve the node (low priority) or OOM it
-        # (max_heap_size makes the VM kill this process at the budget).
-        # Both flags also cover tool code called inline from the eval.
-        Process.flag(:priority, :low)
+        # Generated code must not starve the node (hence the default :low
+        # priority) or OOM it (max_heap_size makes the VM kill this process once
+        # its heap and stack pass the budget; binaries are the parent's job, see
+        # await_result/5). Both flags also cover tool code called inline.
+        Process.flag(:priority, priority)
 
         if is_integer(max_heap_bytes) do
-          heap_words = div(max_heap_bytes, :erlang.system_info(:wordsize))
+          # A size of 0 means "no limit" and the VM rejects anything under its
+          # own minimum heap, so a small budget floors at that minimum - left
+          # alone, it would silently disable the flag or fail to set it at all.
+          {:min_heap_size, min_words} = :erlang.system_info(:min_heap_size)
+          heap_words = max(div(max_heap_bytes, :erlang.system_info(:wordsize)), min_words)
           Process.flag(:max_heap_size, %{size: heap_words, kill: true, error_logger: false})
         end
 
@@ -109,10 +127,10 @@ defmodule Legion.Sandbox do
     await_result(pid, ref, deadline, max_reductions, max_heap_bytes)
   end
 
-  # How often the parent samples the eval's reduction counter. Only relevant
-  # when a :max_reductions limit is set - the budget can be overshot by up to
-  # one interval's worth of work.
-  @reduction_poll_interval_ms 50
+  # How often the parent samples the eval's reduction counter and binary
+  # footprint. Only relevant when one of those limits is set - either budget
+  # can be overshot by up to one interval's worth of work.
+  @poll_interval_ms 50
 
   defp await_result(pid, ref, deadline, max_reductions, max_heap_bytes) do
     receive do
@@ -123,13 +141,14 @@ defmodule Legion.Sandbox do
       # A :killed exit with a heap budget set is the VM enforcing it - nothing
       # else brutally kills the eval while we still hold its monitor.
       {:DOWN, ^ref, :process, _pid, :killed} when is_integer(max_heap_bytes) ->
-        {:error, "evaluation exceeded the memory limit and was killed"}
+        {:error, memory_limit_error()}
 
       {:DOWN, ^ref, :process, _pid, reason} ->
         {:error, {:process_crashed, reason}}
     after
-      wait_ms(deadline, max_reductions) ->
+      wait_ms(deadline, polling?(max_reductions, max_heap_bytes)) ->
         reductions = reductions_over_budget(pid, max_reductions)
+        binary_bytes = binaries_over_budget(pid, max_heap_bytes)
 
         cond do
           deadline != :infinity and System.monotonic_time(:millisecond) >= deadline ->
@@ -142,21 +161,30 @@ defmodule Legion.Sandbox do
             {:error,
              "evaluation exceeded the reduction (CPU) limit after ~#{reductions} reductions and was killed"}
 
+          binary_bytes != nil ->
+            kill(pid, ref)
+            {:error, memory_limit_error()}
+
           true ->
             await_result(pid, ref, deadline, max_reductions, max_heap_bytes)
         end
     end
   end
 
-  defp wait_ms(:infinity, :infinity), do: :infinity
-  defp wait_ms(deadline, :infinity), do: max(deadline - System.monotonic_time(:millisecond), 0)
-  defp wait_ms(:infinity, _max_reductions), do: @reduction_poll_interval_ms
+  defp memory_limit_error, do: "evaluation exceeded the memory limit and was killed"
 
-  defp wait_ms(deadline, _max_reductions) do
+  defp polling?(max_reductions, max_heap_bytes),
+    do: is_integer(max_reductions) or is_integer(max_heap_bytes)
+
+  defp wait_ms(:infinity, false), do: :infinity
+  defp wait_ms(deadline, false), do: max(deadline - System.monotonic_time(:millisecond), 0)
+  defp wait_ms(:infinity, true), do: @poll_interval_ms
+
+  defp wait_ms(deadline, true) do
     deadline
     |> Kernel.-(System.monotonic_time(:millisecond))
     |> max(0)
-    |> min(@reduction_poll_interval_ms)
+    |> min(@poll_interval_ms)
   end
 
   defp reductions_over_budget(_pid, :infinity), do: nil
@@ -167,6 +195,22 @@ defmodule Legion.Sandbox do
     case Process.info(pid, :reductions) do
       {:reductions, reductions} when reductions > max_reductions -> reductions
       _ -> nil
+    end
+  end
+
+  defp binaries_over_budget(_pid, :infinity), do: nil
+
+  defp binaries_over_budget(pid, max_heap_bytes) do
+    # :max_heap_size counts the heap and stack only, so binaries over 64 bytes
+    # - the cheapest way for generated code to eat the node - slip past it.
+    # A process can reference the same binary many times, hence the uniq.
+    with {:binary, entries} <- Process.info(pid, :binary) do
+      bytes =
+        entries
+        |> Enum.uniq_by(&elem(&1, 0))
+        |> Enum.sum_by(&elem(&1, 1))
+
+      if bytes > max_heap_bytes, do: bytes
     end
   end
 

--- a/lib/legion/telemetry.ex
+++ b/lib/legion/telemetry.ex
@@ -45,7 +45,13 @@ defmodule Legion.Telemetry do
 
   - `[:legion, :sandbox, :eval, :start | :stop | :exception]`
     - Metadata includes: `agent`, `agent_id`, `code`
-    - Stop adds: `success`, `result` or `error`
+    - Stop adds: `success`, `result` or `error`, and `denied_by` when a
+      `Legion.EvalGuard` refused the code (in which case it never ran)
+
+  ## Eval Guard Events
+
+  - `[:legion, :eval_guard, :denied]` — a guard refused generated code
+    - Metadata: `%{agent: module, agent_id: term, guard: module, code: String.t(), reason: String.t()}`
 
   ## Default Logger
 

--- a/lib/legion/telemetry.ex
+++ b/lib/legion/telemetry.ex
@@ -45,8 +45,7 @@ defmodule Legion.Telemetry do
 
   - `[:legion, :sandbox, :eval, :start | :stop | :exception]`
     - Metadata includes: `agent`, `agent_id`, `code`
-    - Stop adds: `success`, `result` or `error`, and `denied_by` when a
-      `Legion.EvalGuard` refused the code (in which case it never ran)
+    - Stop adds: `success` and `result` or `error`.
 
   ## Eval Guard Events
 

--- a/test/integration/eval_guard_test.exs
+++ b/test/integration/eval_guard_test.exs
@@ -1,0 +1,67 @@
+defmodule Legion.Integration.EvalGuardTest do
+  @moduledoc """
+  Integration test: confirm `Legion.EvalGuard.LLM` vets generated code with a
+  real model, on the executor's path.
+
+  Skipped by default to avoid external API calls and LLM costs.
+  Run with:
+
+      mix test test/integration/eval_guard_test.exs --include integration
+  """
+  use ExUnit.Case, async: true
+
+  alias Legion.Test.Support.MathTool
+
+  @moduletag :integration
+  @moduletag timeout: 120_000
+
+  defmodule GuardedMathAgent do
+    @moduledoc "A math agent whose code is reviewed before it runs."
+    use Legion.Agent
+
+    defmodule NoRandomAdd do
+      @moduledoc "Denies the one tool function the agent is asked to call."
+      use Legion.EvalGuard.LLM,
+        policy: """
+        Deny any code that calls random_add. Allow everything else, including
+        plain arithmetic.
+        """
+    end
+
+    def tools, do: [Legion.Test.Support.MathTool]
+    def config, do: %{eval_guard: NoRandomAdd, max_iterations: 3, max_retries: 1}
+  end
+
+  setup context do
+    unless System.get_env("OPENAI_API_KEY"), do: raise("OPENAI_API_KEY not set")
+
+    test_pid = self()
+    handler_id = {__MODULE__, context.test}
+
+    :telemetry.attach(
+      handler_id,
+      [:legion, :eval_guard, :denied],
+      fn _event, _measurements, metadata, _config ->
+        send(test_pid, {:denied, metadata.reason})
+      end,
+      nil
+    )
+
+    on_exit(fn -> :telemetry.detach(handler_id) end)
+  end
+
+  test "the model denies code the policy forbids" do
+    Legion.execute(GuardedMathAgent, "Call #{inspect(MathTool)}.random_add(2, 3) and return it.")
+
+    assert_received {:denied, reason}
+    assert reason =~ "random_add"
+  end
+
+  test "code the policy allows runs" do
+    assert {:ok, result} =
+             Legion.execute(GuardedMathAgent, "What is 21 + 21? Compute it and return it.")
+
+    assert result =~ "42"
+    refute_received {:denied, _reason}
+  end
+end

--- a/test/legion/eval_guard/llm_test.exs
+++ b/test/legion/eval_guard/llm_test.exs
@@ -1,0 +1,71 @@
+defmodule Legion.EvalGuard.LLMTest do
+  use ExUnit.Case, async: true
+  use Mimic
+
+  alias Legion.EvalGuard.LLM
+
+  defmodule Reviewer do
+    use Legion.EvalGuard.LLM, policy: "No looping over checkout."
+  end
+
+  defmodule DefaultReviewer do
+    use Legion.EvalGuard.LLM
+  end
+
+  @context %{agent: SomeAgent, agent_id: "conversation-1", tools: [SomeTool]}
+
+  test "an allow verdict passes the code through" do
+    stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+      {:ok, %{object: %{"verdict" => "allow", "reason" => ""}}}
+    end)
+
+    assert Legion.EvalGuard.check(Reviewer, "1 + 1", @context) == :allow
+  end
+
+  test "a deny verdict hands the model's reason back" do
+    stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+      {:ok, %{object: %{"verdict" => "deny", "reason" => "that loops over checkout"}}}
+    end)
+
+    assert Legion.EvalGuard.check(Reviewer, "Enum.each(carts, &Shop.checkout/1)", @context) ==
+             {:deny, "that loops over checkout"}
+  end
+
+  test "a failed review request denies" do
+    stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> {:error, :timeout} end)
+
+    assert {:deny, reason} = Legion.EvalGuard.check(Reviewer, "1 + 1", @context)
+    assert reason =~ "timeout"
+  end
+
+  test "the policy, agent and tools reach the model" do
+    test_pid = self()
+
+    stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
+      send(test_pid, {:reviewed, messages})
+      {:ok, %{object: %{"verdict" => "allow", "reason" => ""}}}
+    end)
+
+    Legion.EvalGuard.check(Reviewer, "Shop.checkout()", @context)
+
+    assert_received {:reviewed, [system, user]}
+    assert system.content =~ "No looping over checkout."
+    assert system.content =~ "SomeAgent"
+    assert system.content =~ "SomeTool"
+    assert user.content == "Shop.checkout()"
+  end
+
+  test "a guard without a policy reviews against the default one" do
+    test_pid = self()
+
+    stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
+      send(test_pid, {:reviewed, messages})
+      {:ok, %{object: %{"verdict" => "allow", "reason" => ""}}}
+    end)
+
+    Legion.EvalGuard.check(DefaultReviewer, "1 + 1", @context)
+
+    assert_received {:reviewed, [system, _user]}
+    assert system.content =~ LLM.default_policy()
+  end
+end

--- a/test/legion/eval_guard_test.exs
+++ b/test/legion/eval_guard_test.exs
@@ -1,0 +1,69 @@
+defmodule Legion.EvalGuardTest do
+  use ExUnit.Case, async: true
+
+  defmodule DenyEverything do
+    @behaviour Legion.EvalGuard
+
+    @impl true
+    def check(_code, _context), do: {:deny, "the shop is closed for renovations"}
+  end
+
+  defmodule AllowEverything do
+    @behaviour Legion.EvalGuard
+
+    @impl true
+    def check(_code, _context), do: :allow
+  end
+
+  defmodule RecordContext do
+    @behaviour Legion.EvalGuard
+
+    @impl true
+    def check(code, context) do
+      send(self(), {:checked, code, context})
+      :allow
+    end
+  end
+
+  @context %{agent: SomeAgent, agent_id: "conversation-1", tools: [SomeTool]}
+
+  test "no guard configured allows everything" do
+    assert Legion.EvalGuard.check(nil, "System.halt()", @context) == :allow
+  end
+
+  test "an allowing guard passes the code through" do
+    assert Legion.EvalGuard.check(AllowEverything, "1 + 1", @context) == :allow
+  end
+
+  test "a denying guard returns its reason" do
+    assert {:deny, reason} = Legion.EvalGuard.check(DenyEverything, "1 + 1", @context)
+    assert reason =~ "renovations"
+  end
+
+  test "a denial emits telemetry carrying the code and reason" do
+    :telemetry.attach(
+      "guard-denied-test",
+      [:legion, :eval_guard, :denied],
+      fn event, _measurements, metadata, pid -> send(pid, {:telemetry, event, metadata}) end,
+      self()
+    )
+
+    on_exit(fn -> :telemetry.detach("guard-denied-test") end)
+
+    Legion.EvalGuard.check(DenyEverything, "Shop.checkout()", @context)
+
+    assert_receive {:telemetry, [:legion, :eval_guard, :denied], metadata}
+    assert metadata.guard == DenyEverything
+    assert metadata.code == "Shop.checkout()"
+    assert metadata.reason =~ "renovations"
+  end
+
+  test "the guard receives the code and the agent context" do
+    Legion.EvalGuard.check(RecordContext, "Shop.list_records()", @context)
+
+    assert_receive {:checked, "Shop.list_records()", context}
+    assert context.agent == SomeAgent
+    assert context.agent_id == "conversation-1"
+    assert context.tools == [SomeTool]
+  end
+end

--- a/test/legion/eval_guard_test.exs
+++ b/test/legion/eval_guard_test.exs
@@ -1,6 +1,8 @@
 defmodule Legion.EvalGuardTest do
   use ExUnit.Case, async: true
 
+  import ExUnit.CaptureLog
+
   defmodule DenyEverything do
     @behaviour Legion.EvalGuard
 
@@ -40,6 +42,7 @@ defmodule Legion.EvalGuardTest do
     assert reason =~ "renovations"
   end
 
+  @tag capture_log: true
   test "a denial emits telemetry carrying the code and reason" do
     :telemetry.attach(
       "guard-denied-test",
@@ -56,6 +59,42 @@ defmodule Legion.EvalGuardTest do
     assert metadata.guard == DenyEverything
     assert metadata.code == "Shop.checkout()"
     assert metadata.reason =~ "renovations"
+  end
+
+  defmodule Broken do
+    @behaviour Legion.EvalGuard
+
+    @impl true
+    def check("raise", _context), do: raise("the reviewer is on fire")
+    def check("throw", _context), do: throw(:nope)
+    def check("exit", _context), do: exit(:shutdown)
+    def check("garbage", _context), do: :maybe
+  end
+
+  test "a guard that raises denies rather than taking the caller down" do
+    log =
+      capture_log(fn ->
+        assert {:deny, reason} = Legion.EvalGuard.check(Broken, "raise", @context)
+        assert reason =~ "the reviewer is on fire"
+      end)
+
+    assert log =~ "[error]"
+    assert log =~ "Broken failed to return a verdict"
+  end
+
+  @tag capture_log: true
+  test "a guard that throws or exits denies" do
+    assert {:deny, thrown} = Legion.EvalGuard.check(Broken, "throw", @context)
+    assert thrown =~ ":nope"
+
+    assert {:deny, exited} = Legion.EvalGuard.check(Broken, "exit", @context)
+    assert exited =~ ":shutdown"
+  end
+
+  @tag capture_log: true
+  test "a guard returning something that is not a verdict denies" do
+    assert {:deny, reason} = Legion.EvalGuard.check(Broken, "garbage", @context)
+    assert reason =~ ":maybe"
   end
 
   test "the guard receives the code and the agent context" do

--- a/test/legion/executor_test.exs
+++ b/test/legion/executor_test.exs
@@ -144,6 +144,56 @@ defmodule Legion.ExecutorTest do
       assert {:cancel, :reached_max_retries} = Legion.execute(MathAgent, "fail")
     end
 
+    test "eval_guard denial stops the code from running and reaches the agent" do
+      defmodule NoArithmetic do
+        @behaviour Legion.EvalGuard
+
+        @impl true
+        def check(code, _context) do
+          if String.contains?(code, "+"),
+            do: {:deny, "addition is off limits here"},
+            else: :allow
+        end
+      end
+
+      call_count = :counters.new(1, [:atomics])
+
+      stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
+        :counters.add(call_count, 1, 1)
+
+        case :counters.get(call_count, 1) do
+          1 ->
+            response(%{"action" => "eval_and_complete", "code" => "1 + 1", "result" => ""})
+
+          2 ->
+            # The agent is told why, in the conversation, and can adapt.
+            assert Enum.any?(
+                     messages,
+                     &(is_binary(&1.content) and &1.content =~ "addition is off limits")
+                   )
+
+            response(%{"action" => "eval_and_complete", "code" => "21 * 2", "result" => ""})
+        end
+      end)
+
+      assert {:ok, 42} = Legion.execute(MathAgent, "add things", eval_guard: NoArithmetic)
+    end
+
+    test "eval_guard allowing code leaves execution untouched" do
+      defmodule AllowAll do
+        @behaviour Legion.EvalGuard
+
+        @impl true
+        def check(_code, _context), do: :allow
+      end
+
+      stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+        response(%{"action" => "eval_and_complete", "code" => "2 + 2", "result" => ""})
+      end)
+
+      assert {:ok, 4} = Legion.execute(MathAgent, "add", eval_guard: AllowAll)
+    end
+
     test "LLM error triggers retry" do
       call_count = :counters.new(1, [:atomics])
 

--- a/test/legion/sandbox_test.exs
+++ b/test/legion/sandbox_test.exs
@@ -27,6 +27,41 @@ defmodule Legion.SandboxTest do
     assert {:error, {:exit, :boom}} = Legion.Sandbox.execute("exit(:boom)", 15_000)
   end
 
+  test "eval exceeding the heap budget is killed with a memory error" do
+    assert {:error, message} =
+             Legion.Sandbox.execute("Enum.to_list(1..50_000_000)", 15_000, [], [],
+               max_heap: 10_000_000
+             )
+
+    assert message =~ "memory limit"
+  end
+
+  test "a brutal kill without a heap budget reports a crash, not a memory limit" do
+    # The AST checker blocks Process for generated code; allowing it here is
+    # the only way to provoke the :killed exit an external kill would cause.
+    assert {:error, {:process_crashed, :killed}} =
+             Legion.Sandbox.execute("Process.exit(self(), :kill)", 15_000, [Process])
+  end
+
+  test "heap budget leaves ordinary evals untouched" do
+    assert {:ok, {499_500, _}} =
+             Legion.Sandbox.execute("Enum.sum(1..999)", 15_000, [], [], max_heap: 10_000_000)
+  end
+
+  test "eval exceeding the reduction budget is killed with a CPU error" do
+    code = "Enum.reduce(1..100_000_000, 0, fn n, acc -> acc + n end)"
+
+    assert {:error, message} =
+             Legion.Sandbox.execute(code, 60_000, [], [], max_reductions: 1_000_000)
+
+    assert message =~ "reduction (CPU) limit"
+  end
+
+  test "reduction budget leaves ordinary evals untouched" do
+    assert {:ok, {499_500, _}} =
+             Legion.Sandbox.execute("Enum.sum(1..999)", 15_000, [], [], max_reductions: 1_000_000)
+  end
+
   test "compile error surfaces diagnostics instead of the generic wrapper message" do
     code = ~S|x = 1
 String.upcase(t)|

--- a/test/legion/sandbox_test.exs
+++ b/test/legion/sandbox_test.exs
@@ -40,7 +40,9 @@ defmodule Legion.SandboxTest do
     # The AST checker blocks Process for generated code; allowing it here is
     # the only way to provoke the :killed exit an external kill would cause.
     assert {:error, {:process_crashed, :killed}} =
-             Legion.Sandbox.execute("Process.exit(self(), :kill)", 15_000, [Process])
+             Legion.Sandbox.execute("Process.exit(self(), :kill)", 15_000, [Process], [],
+               max_heap: :infinity
+             )
   end
 
   test "heap budget leaves ordinary evals untouched" do
@@ -60,6 +62,50 @@ defmodule Legion.SandboxTest do
   test "reduction budget leaves ordinary evals untouched" do
     assert {:ok, {499_500, _}} =
              Legion.Sandbox.execute("Enum.sum(1..999)", 15_000, [], [], max_reductions: 1_000_000)
+  end
+
+  test "eval piling up binaries is killed by the heap budget even though they live off-heap" do
+    code = """
+    chunk = String.duplicate("x", 1_000_000)
+    Enum.reduce(1..500, "", fn _, acc -> acc <> chunk end) |> byte_size()
+    """
+
+    assert {:error, message} = Legion.Sandbox.execute(code, 30_000, [], [], max_heap: 10_000_000)
+    assert message =~ "memory limit"
+  end
+
+  test "binaries under the heap budget are left alone, even referenced many times over" do
+    code = """
+    chunk = String.duplicate("x", 1_000_000)
+    List.duplicate(chunk, 500) |> Enum.map(&byte_size/1) |> Enum.sum()
+    """
+
+    assert {:ok, {500_000_000, _}} =
+             Legion.Sandbox.execute(code, 30_000, [], [], max_heap: 10_000_000)
+  end
+
+  test "a heap budget below the VM's minimum still bounds the eval" do
+    assert {:error, message} =
+             Legion.Sandbox.execute("Enum.to_list(1..3_000_000)", 15_000, [], [], max_heap: 4)
+
+    assert message =~ "memory limit"
+  end
+
+  test "priority defaults to low and is configurable" do
+    # Process is off limits to generated code; the test allows it to read the flag back.
+    code = "Process.info(self(), :priority)"
+
+    assert {:ok, {{:priority, :low}, _}} = Legion.Sandbox.execute(code, 15_000, [Process])
+
+    assert {:ok, {{:priority, :normal}, _}} =
+             Legion.Sandbox.execute(code, 15_000, [Process], [], priority: :normal)
+  end
+
+  test "generated code cannot raise its own priority" do
+    assert {:error, message} =
+             Legion.Sandbox.execute("Process.flag(:priority, :high)", 15_000)
+
+    assert message =~ "Module Process is not allowed"
   end
 
   test "compile error surfaces diagnostics instead of the generic wrapper message" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -18,7 +18,8 @@ end
     port: String.to_integer(System.get_env("POSTGRES_PORT", "5432")),
     username: System.get_env("POSTGRES_USER", "postgres"),
     password: System.get_env("POSTGRES_PASSWORD", "postgres"),
-    database: System.get_env("POSTGRES_DB", "postgres")
+    database: System.get_env("POSTGRES_DB", "postgres"),
+    log: false
   )
 
 Ecto.Migrator.up(


### PR DESCRIPTION
Previous sandbox-related work focused on preventing RCEs, this PR focuses on preventing DoS.

This PR introduces two new safety knobs for generated code: `sandbox_max_heap` / `sandbox_max_reductions` bound the eval process's memory and CPU (VM-enforced kill and polled reduction budget), and `eval_guard` plugs a `Legion.EvalGuard` module in front of the sandbox for policy the AST checker can't express. Also prompts plain-text output schemas to answer without JSON wrapping.

