### PR TITLE
Make Lua the default sandbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Changes
 
-- Make sandboxes pluggable: `Legion.Sandbox` is now a behaviour selected per agent (or globally) with the `sandbox` config key, opening the door to sandboxes such as [popcorn](https://github.com/software-mansion/popcorn/) in the user's browser. The Elixir implementation moved to `Legion.Sandbox.Elixir` (still the default), and the process isolation with timeout / memory / CPU budgets was extracted to `Legion.Sandbox.Runner`, shared by all sandboxes
+- Make sandboxes pluggable: `Legion.Sandbox` is now a behaviour selected per agent (or globally) with the `sandbox` config key, opening the door to sandboxes such as [popcorn](https://github.com/software-mansion/popcorn/) in the user's browser. The Elixir implementation moved to `Legion.Sandbox.Elixir`, and the process isolation with timeout / memory / CPU budgets was extracted to `Legion.Sandbox.Runner`, shared by all sandboxes
 - Add `Legion.Sandbox.Lua` - agents write Lua evaluated by [lua](https://hexdocs.pm/lua), a Lua 5.3 VM in pure Elixir. Generated code cannot reach the host BEAM at all (no AST allowlist to escape); tools are bridged in as global Lua tables with values converted at the boundary
+- Make `Legion.Sandbox.Lua` the default sandbox. Agents now write Lua unless configured otherwise; set `sandbox: Legion.Sandbox.Elixir` (per agent or globally) to keep agents writing Elixir. Note that only `Legion.Tool` modules are callable from Lua - plain modules passed as tools (e.g. `Jason`) are reference-only there
 - Add `Legion.Store` for persisting conversations across process and application restarts; stores exchange partial `Legion.Store.Payload` values containing conversation state and metadata through `get/1` and `save/1`
 - Persist the user message with `status: :running` before execution and the final conversation with `status: :idle` before replying, so a reply is a commit receipt for the completed turn
 - Add optional `persistence_frequency/0`; stores default to `:turn`, while `:step` also checkpoints intermediate eval results, recoverable errors, bindings, and executor progress. Interrupted turns are recorded but are not resumed automatically

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 **Legion is an Elixir framework for AI agents that live inside your application and get things done by writing code.** 
 
-Define an agent's responsibilities, give it tools to interact with your app safely, and hand it a task from one of your users. It will read the source of the modules you expose, write an Elixir (or Lua) snippet, run it in a sandbox, look at the result, and write the next one - until the task is done.
+Define an agent's responsibilities, give it tools to interact with your app safely, and hand it a task from one of your users. It will read the source of the modules you expose, write a Lua (or Elixir) snippet, run it in a sandbox, look at the result, and write the next one - until the task is done.
 
 One evaluation can filter, branch, and loop - work that would cost a tool-calling agent an LLM round trip per step ([Anthropic on why code execution beats tool calling](https://www.anthropic.com/engineering/code-execution-with-mcp)).
 
@@ -137,8 +137,8 @@ Start one, keep it around, and message it like a GenServer.
 ### **3. Generated code runs in a sandbox**
 
 Every evaluation runs in a monitored process with timeout, memory, and CPU budgets. Two sandboxes ship with Legion, differing in language and trust model:
-   - [`Legion.Sandbox.Elixir`](https://hexdocs.pm/legion/Legion.Sandbox.Elixir.html) (default) - agents write Elixir. Dangerous constructs (`defmodule`, `import`, `spawn`, `send`, `apply`, ...) are blocked at the AST level and module access is allowlisted (stdlib + your tools). Powerful, but the allowlist guards an enormous language surface - use it for your own LLM-backed agents with controlled tool access, not arbitrary code from unknown sources.
-   - [`Legion.Sandbox.Lua`](https://hexdocs.pm/legion/Legion.Sandbox.Lua.html) - agents write Lua, evaluated by [lua](https://hexdocs.pm/lua), a Lua 5.3 VM in pure Elixir. Lua code cannot reach the host BEAM at all - the only bridges out are the tool functions Legion registers - making it the safer choice for less trusted generation.
+   - [`Legion.Sandbox.Lua`](https://hexdocs.pm/legion/Legion.Sandbox.Lua.html) (default) - agents write Lua, evaluated by [lua](https://hexdocs.pm/lua), a Lua 5.3 VM in pure Elixir. Lua code cannot reach the host BEAM at all - the only bridges out are the tool functions Legion registers - making it the safer choice for less trusted generation.
+   - [`Legion.Sandbox.Elixir`](https://hexdocs.pm/legion/Legion.Sandbox.Elixir.html) - agents write Elixir. Dangerous constructs (`defmodule`, `import`, `spawn`, `send`, `apply`, ...) are blocked at the AST level and module access is allowlisted (stdlib + your tools). Powerful, but the allowlist guards an enormous language surface - use it for your own LLM-backed agents with controlled tool access, not arbitrary code from unknown sources.
 
    Neither is OS-level isolation - evaluation still runs inside your BEAM VM. If your threat model requires that, run agents in a separate BEAM instance. Custom sandboxes (for example, executing in the user's browser via [popcorn](https://github.com/software-mansion/popcorn/)) implement the [`Legion.Sandbox`](https://hexdocs.pm/legion/Legion.Sandbox.html) behaviour.
 
@@ -271,7 +271,7 @@ config :legion, :config, %{
 | `model`              | LLM model string passed to [ReqLLM](https://hexdocs.pm/req_llm), e.g. `"openai:gpt-5.4"`.                                  |
 | `max_iterations`     | Successful execution steps before the agent is stopped.                                                                    |
 | `max_retries`        | Consecutive failures (bad code, tool errors) before giving up. Resets after each success.                                  |
-| `sandbox`            | Sandbox module evaluating generated code: `Legion.Sandbox.Elixir` (default) or `Legion.Sandbox.Lua`. See [Sandboxing](#sandboxing). |
+| `sandbox`            | Sandbox module evaluating generated code: `Legion.Sandbox.Lua` (default) or `Legion.Sandbox.Elixir`. See [Sandboxing](#sandboxing). |
 | `sandbox_timeout`    | Milliseconds a single code evaluation may run before it is killed.                                                         |
 | `binding_scope`      | `:iteration` (fresh each step), `:turn` (persist within a message, default), or `:conversation` (persist across messages). |
 | `max_message_length` | Byte limit for any single message. Longer content is truncated. Set to `:infinity` to disable.                             |
@@ -310,8 +310,8 @@ Events emitted at every level:
 
 Sandboxes are pluggable via the `sandbox` config key. Both built-in sandboxes run evaluations in a monitored process with timeout, memory, and CPU budgets (`sandbox_timeout`, `sandbox_max_heap`, `sandbox_max_reductions`); they differ in language and trust model:
 
-- **`Legion.Sandbox.Elixir`** (default) - agents write Elixir. Dangerous constructs (`defmodule`, `import`, `spawn`, `send`, `apply`, ...) are blocked at the AST level and module access is limited to an allowlist (stdlib + your tools). Powerful - tools are plain Elixir calls - but the allowlist guards an enormous language surface, and new escape vectors could be found. Use it for trusted code generators (your own LLM-backed agents with controlled tool access), not arbitrary code from unknown sources.
-- **`Legion.Sandbox.Lua`** - agents write Lua, evaluated by [lua](https://hexdocs.pm/lua), a Lua 5.3 VM implemented in pure Elixir. Lua code has no way to reach the host BEAM at all - the only bridges out of the VM are the tool functions Legion registers - which makes it the safer choice when the generated code is less trusted. Tool arguments and results are converted at the boundary (Lua tables to maps/lists and back; Elixir tuples become arrays, atoms become strings).
+- **`Legion.Sandbox.Lua`** (default) - agents write Lua, evaluated by [lua](https://hexdocs.pm/lua), a Lua 5.3 VM implemented in pure Elixir. Lua code has no way to reach the host BEAM at all - the only bridges out of the VM are the tool functions Legion registers - which makes it the safer choice when the generated code is less trusted. Tool arguments and results are converted at the boundary (Lua tables to maps/lists and back; Elixir tuples become arrays, atoms become strings).
+- **`Legion.Sandbox.Elixir`** - agents write Elixir. Dangerous constructs (`defmodule`, `import`, `spawn`, `send`, `apply`, ...) are blocked at the AST level and module access is limited to an allowlist (stdlib + your tools). Powerful - tools are plain Elixir calls - but the allowlist guards an enormous language surface, and new escape vectors could be found. Use it for trusted code generators (your own LLM-backed agents with controlled tool access), not arbitrary code from unknown sources.
 
 Neither sandbox is full OS-level isolation - evaluation still runs inside your BEAM VM. If your threat model requires that, run agents in a separate BEAM instance.
 

--- a/lib/legion/agent.ex
+++ b/lib/legion/agent.ex
@@ -39,10 +39,10 @@ defmodule Legion.Agent do
       call-time opts. Defaults to `%{}`. Available keys:
       - `model` — LLM model identifier (default: `"openai:gpt-5.4"`)
       - `sandbox` — a `Legion.Sandbox` module that validates and evaluates the
-        code the agent writes. `Legion.Sandbox.Elixir` (the default) evaluates
-        Elixir behind an AST allowlist; `Legion.Sandbox.Lua` evaluates Lua in a
-        pure-Erlang VM where only bridged tool functions can reach the host
-        (default: `Legion.Sandbox.Elixir`)
+        code the agent writes. `Legion.Sandbox.Lua` (the default) evaluates Lua
+        in a pure-Erlang VM where only bridged tool functions can reach the
+        host; `Legion.Sandbox.Elixir` evaluates Elixir behind an AST allowlist
+        (default: `Legion.Sandbox.Lua`)
       - `max_iterations` — max successful execution steps per turn (default: `10`)
       - `max_retries` — max consecutive failures before giving up (default: `3`)
       - `sandbox_timeout` — timeout in ms for code execution (default: `60_000`)

--- a/lib/legion/agent_prompt.ex
+++ b/lib/legion/agent_prompt.ex
@@ -19,7 +19,7 @@ defmodule Legion.AgentPrompt do
     tool_contents = Enum.map(agent.tools(), &tool_description/1)
     description = agent.moduledoc()
     binding_scope = Map.get(config, :binding_scope, :turn)
-    sandbox = Map.get(config, :sandbox, Legion.Sandbox.Elixir)
+    sandbox = Map.get(config, :sandbox, Legion.Sandbox.Lua)
     prompt_info = sandbox.prompt_info()
 
     {result, _} =

--- a/lib/legion/eval_guard/llm.ex
+++ b/lib/legion/eval_guard/llm.ex
@@ -110,7 +110,7 @@ defmodule Legion.EvalGuard.LLM do
 
   defp system_prompt(policy, context) do
     """
-    You are reviewing Elixir code an AI agent wrote, before it runs in a sandbox.
+    You are reviewing code an AI agent wrote, before it runs in a sandbox.
     Allow anything the policy does not forbid - you are the last check, not the
     only one, and a wrongly denied eval costs the agent a turn.
 

--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -16,7 +16,7 @@ defmodule Legion.Executor do
     model: "openai:gpt-5.4",
     max_iterations: 10,
     max_retries: 3,
-    sandbox: Legion.Sandbox.Elixir,
+    sandbox: Legion.Sandbox.Lua,
     sandbox_timeout: 60_000,
     sandbox_max_heap: Runner.default_max_heap(),
     sandbox_max_reductions: :infinity,

--- a/lib/legion/sandbox.ex
+++ b/lib/legion/sandbox.ex
@@ -8,18 +8,19 @@ defmodule Legion.Sandbox do
 
   Built-in implementations:
 
-    - `Legion.Sandbox.Elixir` (default) — evaluates Elixir with AST-level
-      allowlist checking. Powerful (tools are plain Elixir calls) but the
-      allowlist is a blocklist-shaped problem: new RCE vectors in the huge
-      Elixir surface are found regularly.
-    - `Legion.Sandbox.Lua` — evaluates Lua via [lua](https://hexdocs.pm/lua),
-      a Lua 5.3 VM written in pure Elixir. Nothing in the Lua world can touch the
-      host BEAM except the tool functions you explicitly bridge in, which makes
-      it the safer choice for less trusted code.
+    - `Legion.Sandbox.Lua` (default) — evaluates Lua via
+      [lua](https://hexdocs.pm/lua), a Lua 5.3 VM written in pure Elixir.
+      Nothing in the Lua world can touch the host BEAM except the tool
+      functions you explicitly bridge in, which makes it the safer choice for
+      less trusted code.
+    - `Legion.Sandbox.Elixir` — evaluates Elixir with AST-level allowlist
+      checking. Powerful (tools are plain Elixir calls) but the allowlist is a
+      blocklist-shaped problem: new RCE vectors in the huge Elixir surface are
+      found regularly.
 
   Select per agent (or globally) with the `:sandbox` config key:
 
-      def config, do: %{sandbox: Legion.Sandbox.Lua}
+      def config, do: %{sandbox: Legion.Sandbox.Elixir}
 
   Both built-ins evaluate inside `Legion.Sandbox.Runner`, which enforces the
   timeout, memory, and CPU limits regardless of language. Nothing above

--- a/lib/legion/sandbox/elixir.ex
+++ b/lib/legion/sandbox/elixir.ex
@@ -1,7 +1,6 @@
 defmodule Legion.Sandbox.Elixir do
   @moduledoc """
-  Sandboxed Elixir evaluation with AST-level safety checks. The default
-  `Legion.Sandbox`.
+  Sandboxed Elixir evaluation with AST-level safety checks.
 
   Evaluates Elixir code strings in a spawned process with:
 

--- a/lib/legion/sandbox/lua.ex
+++ b/lib/legion/sandbox/lua.ex
@@ -1,7 +1,7 @@
 defmodule Legion.Sandbox.Lua do
   @moduledoc """
   Sandboxed Lua evaluation via [lua](https://hexdocs.pm/lua) - a Lua 5.3 VM
-  written in pure Elixir.
+  written in pure Elixir. The default `Legion.Sandbox`.
 
   Unlike `Legion.Sandbox.Elixir`, which must deny-list its way around the
   entire Elixir surface, Lua code simply has no way to reach the host BEAM:

--- a/lib/legion/sandbox/lua/constraints.eex
+++ b/lib/legion/sandbox/lua/constraints.eex
@@ -3,4 +3,4 @@
 - `print`, `io`, `os.getenv`, `require`, and `load` are not available - return values from your code instead of printing them.
 - Tools are Elixir functions bridged into Lua. Arguments you pass are converted: Lua tables become maps (or lists when array-shaped). Results are converted back: maps and structs become tables, Elixir tuples and lists become arrays (1-indexed), atoms become strings (`:ok` arrives as `"ok"`).
 - Where a tool expects an Elixir module reference (for example `AgentTool.call(PlannerAgent, task)`), pass the tool's global table directly by its short name - it is converted to the module automatically.
-- The standard `string`, `table`, and `math` libraries are available.
+- The standard `string`, `table`, and `math` libraries are available - standard Lua 5.3 only. `table.create` and `table.count` do not exist here (they are Luau extensions); use `#t` for length and `table.insert(t, value)` to build lists.

--- a/test/integration/eval_guard_test.exs
+++ b/test/integration/eval_guard_test.exs
@@ -28,7 +28,7 @@ defmodule Legion.Integration.EvalGuardTest do
         """
     end
 
-    def tools, do: [Legion.Test.Support.MathTool]
+    def tools, do: [MathTool]
     def config, do: %{eval_guard: NoRandomAdd, max_iterations: 3, max_retries: 1}
   end
 
@@ -42,7 +42,11 @@ defmodule Legion.Integration.EvalGuardTest do
       handler_id,
       [:legion, :eval_guard, :denied],
       fn _event, _measurements, metadata, _config ->
-        send(test_pid, {:denied, metadata.reason})
+        # Other tests in the suite emit the same global event concurrently;
+        # only this agent's guard is relevant here.
+        if metadata.guard == GuardedMathAgent.NoRandomAdd do
+          send(test_pid, {:denied, metadata.reason})
+        end
       end,
       nil
     )
@@ -51,7 +55,7 @@ defmodule Legion.Integration.EvalGuardTest do
   end
 
   test "the model denies code the policy forbids" do
-    Legion.execute(GuardedMathAgent, "Call #{inspect(MathTool)}.random_add(2, 3) and return it.")
+    Legion.execute(GuardedMathAgent, "Call MathTool.random_add(2, 3) and return it.")
 
     assert_received {:denied, reason}
     assert reason =~ "random_add"

--- a/test/integration/step_persistence_test.exs
+++ b/test/integration/step_persistence_test.exs
@@ -39,7 +39,12 @@ defmodule Legion.Integration.StepPersistenceTest do
       end
     end)
 
-    {:ok, pid} = Legion.start_link(MathAgent, store: StepStore, agent_id: agent_id)
+    {:ok, pid} =
+      Legion.start_link(MathAgent,
+        store: StepStore,
+        agent_id: agent_id,
+        sandbox: Legion.Sandbox.Elixir
+      )
 
     assert {:ok, "done"} = Legion.call(pid, "compute")
 

--- a/test/legion/agent_prompt_test.exs
+++ b/test/legion/agent_prompt_test.exs
@@ -17,9 +17,9 @@ defmodule Legion.AgentPromptTest do
       assert prompt =~ "An agent that does math."
     end
 
-    test "includes elixir version" do
+    test "includes the sandbox language" do
       prompt = AgentPrompt.system_prompt(MathAgent)
-      assert prompt =~ System.version()
+      assert prompt =~ "Lua"
     end
 
     test "includes custom description when description/0 is overridden" do

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -642,7 +642,7 @@ defmodule Legion.AgentServerTest do
 
     test "does not persist bindings under the default :turn scope" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        llm_eval_response("x = 42")
+        llm_eval_response("x = 42\nreturn x")
       end)
 
       {:ok, pid} = Legion.start_link(MathAgent, store: MemoryStore, agent_id: "turn-bindings")
@@ -659,7 +659,8 @@ defmodule Legion.AgentServerTest do
       {:ok, pid} =
         Legion.start_link(ConversationBindingsAgent,
           store: MemoryStore,
-          agent_id: "conversation-bindings"
+          agent_id: "conversation-bindings",
+          sandbox: Legion.Sandbox.Elixir
         )
 
       assert {:ok, 42} = Legion.call(pid, "set x")
@@ -683,7 +684,11 @@ defmodule Legion.AgentServerTest do
       end)
 
       {:ok, pid} =
-        Legion.start_link(MathAgent, store: StepMemoryStore, agent_id: "step-continue")
+        Legion.start_link(MathAgent,
+          store: StepMemoryStore,
+          agent_id: "step-continue",
+          sandbox: Legion.Sandbox.Elixir
+        )
 
       assert {:ok, "done"} = Legion.call(pid, "compute")
 
@@ -710,7 +715,7 @@ defmodule Legion.AgentServerTest do
 
     test "a :step store persists eval_and_complete before the final snapshot" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        llm_eval_response("1 + 1")
+        llm_eval_response("return 1 + 1")
       end)
 
       {:ok, pid} =
@@ -768,7 +773,8 @@ defmodule Legion.AgentServerTest do
       {:ok, pid} =
         Legion.start_link(ConversationBindingsAgent,
           store: StepMemoryStore,
-          agent_id: "step-conversation-bindings"
+          agent_id: "step-conversation-bindings",
+          sandbox: Legion.Sandbox.Elixir
         )
 
       assert {:ok, 42} = Legion.call(pid, "compute")
@@ -782,7 +788,7 @@ defmodule Legion.AgentServerTest do
 
     test "a :step store persists empty iteration-scoped bindings" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        llm_eval_response("x = 42")
+        llm_eval_response("x = 42\nreturn x")
       end)
 
       {:ok, pid} =
@@ -835,9 +841,9 @@ defmodule Legion.AgentServerTest do
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
         if assistant_count == 0 do
-          llm_eval_response("x = 42")
+          llm_eval_response("x = 42\nreturn x")
         else
-          llm_eval_response("x + 1")
+          llm_eval_response("return x + 1")
         end
       end)
 
@@ -967,9 +973,9 @@ defmodule Legion.AgentServerTest do
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
         if assistant_count == 0 do
-          llm_eval_response("x = 42")
+          llm_eval_response("x = 42\nreturn x")
         else
-          llm_eval_response("x + 1")
+          llm_eval_response("return x + 1")
         end
       end)
 
@@ -986,9 +992,9 @@ defmodule Legion.AgentServerTest do
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
         if assistant_count == 0 do
-          llm_eval_response("x = 42")
+          llm_eval_response("x = 42\nreturn x")
         else
-          llm_eval_response("x + 1")
+          llm_eval_response("return x + 1")
         end
       end)
 
@@ -997,19 +1003,19 @@ defmodule Legion.AgentServerTest do
       assert {:ok, 43} = Legion.call(pid, "use x")
     end
 
-    test "Lua bindings persist across turns with :conversation" do
+    test "Elixir bindings persist across turns with :conversation" do
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
         assistant_count = Enum.count(messages, &(&1[:role] == "assistant"))
 
         if assistant_count == 0 do
           llm_eval_response("x = 42")
         else
-          llm_eval_response("return x + 1")
+          llm_eval_response("x + 1")
         end
       end)
 
-      {:ok, pid} = Legion.start_link(ConversationBindingsAgent, sandbox: Legion.Sandbox.Lua)
-      {:ok, nil} = Legion.call(pid, "set x")
+      {:ok, pid} = Legion.start_link(ConversationBindingsAgent, sandbox: Legion.Sandbox.Elixir)
+      {:ok, 42} = Legion.call(pid, "set x")
       assert {:ok, 43} = Legion.call(pid, "use x")
     end
 

--- a/test/legion/executor_test.exs
+++ b/test/legion/executor_test.exs
@@ -102,7 +102,7 @@ defmodule Legion.ExecutorTest do
 
     test "eval_and_complete executes code and returns result" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        response(%{"action" => "eval_and_complete", "code" => "1 + 1", "result" => ""})
+        response(%{"action" => "eval_and_complete", "code" => "return 1 + 1", "result" => ""})
       end)
 
       assert {:ok, 2} = Legion.execute(MathAgent, "add")
@@ -115,8 +115,11 @@ defmodule Legion.ExecutorTest do
         :counters.add(call_count, 1, 1)
 
         case :counters.get(call_count, 1) do
-          1 -> response(%{"action" => "eval_and_continue", "code" => "x = 10", "result" => ""})
-          2 -> response(%{"action" => "eval_and_complete", "code" => "x * 2", "result" => ""})
+          1 ->
+            response(%{"action" => "eval_and_continue", "code" => "x = 10", "result" => ""})
+
+          2 ->
+            response(%{"action" => "eval_and_complete", "code" => "return x * 2", "result" => ""})
         end
       end)
 
@@ -125,7 +128,7 @@ defmodule Legion.ExecutorTest do
 
     test "cancels after max_iterations" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        response(%{"action" => "eval_and_continue", "code" => "1", "result" => ""})
+        response(%{"action" => "eval_and_continue", "code" => "return 1", "result" => ""})
       end)
 
       assert {:cancel, :reached_max_iterations} =
@@ -136,7 +139,7 @@ defmodule Legion.ExecutorTest do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
         response(%{
           "action" => "eval_and_complete",
-          "code" => "raise \"boom\"",
+          "code" => "error(\"boom\")",
           "result" => ""
         })
       end)
@@ -163,7 +166,7 @@ defmodule Legion.ExecutorTest do
 
         case :counters.get(call_count, 1) do
           1 ->
-            response(%{"action" => "eval_and_complete", "code" => "1 + 1", "result" => ""})
+            response(%{"action" => "eval_and_complete", "code" => "return 1 + 1", "result" => ""})
 
           2 ->
             # The agent is told why, in the conversation, and can adapt.
@@ -172,7 +175,11 @@ defmodule Legion.ExecutorTest do
                      &(is_binary(&1.content) and &1.content =~ "addition is off limits")
                    )
 
-            response(%{"action" => "eval_and_complete", "code" => "21 * 2", "result" => ""})
+            response(%{
+              "action" => "eval_and_complete",
+              "code" => "return 21 * 2",
+              "result" => ""
+            })
         end
       end)
 
@@ -188,7 +195,7 @@ defmodule Legion.ExecutorTest do
       end
 
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
-        response(%{"action" => "eval_and_complete", "code" => "2 + 2", "result" => ""})
+        response(%{"action" => "eval_and_complete", "code" => "return 2 + 2", "result" => ""})
       end)
 
       assert {:ok, 4} = Legion.execute(MathAgent, "add", eval_guard: AllowAll)
@@ -218,7 +225,8 @@ defmodule Legion.ExecutorTest do
         })
       end)
 
-      assert {:ok, ~s({"a":1})} = Legion.execute(ThirdPartyToolAgent, "encode")
+      assert {:ok, ~s({"a":1})} =
+               Legion.execute(ThirdPartyToolAgent, "encode", sandbox: Legion.Sandbox.Elixir)
     end
 
     test "missing action field in LLM response triggers retry" do
@@ -271,7 +279,7 @@ defmodule Legion.ExecutorTest do
                Legion.Executor.run(
                  MathAgent,
                  executor_messages("compute"),
-                 %{checkpoint: checkpoint}
+                 %{checkpoint: checkpoint, sandbox: Legion.Sandbox.Elixir}
                )
 
       assert_received {:checkpoint,
@@ -304,7 +312,7 @@ defmodule Legion.ExecutorTest do
           1 ->
             response(%{
               "action" => "eval_and_complete",
-              "code" => "raise \"boom\"",
+              "code" => "error(\"boom\")",
               "result" => ""
             })
 
@@ -358,7 +366,7 @@ defmodule Legion.ExecutorTest do
 
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
         :counters.add(call_count, 1, 1)
-        response(%{"action" => "eval_and_continue", "code" => "1 + 1", "result" => ""})
+        response(%{"action" => "eval_and_continue", "code" => "return 1 + 1", "result" => ""})
       end)
 
       reason =
@@ -392,7 +400,7 @@ defmodule Legion.ExecutorTest do
           0 ->
             response(%{
               "action" => "eval_and_continue",
-              "code" => "posts = [1, 2]",
+              "code" => "posts = {1, 2}",
               "result" => ""
             })
 
@@ -426,7 +434,7 @@ defmodule Legion.ExecutorTest do
           0 ->
             response(%{
               "action" => "eval_and_continue",
-              "code" => "String.duplicate(\"a\", 5000)",
+              "code" => "return string.rep(\"a\", 5000)",
               "result" => ""
             })
 
@@ -460,7 +468,7 @@ defmodule Legion.ExecutorTest do
           0 ->
             response(%{
               "action" => "eval_and_complete",
-              "code" => "raise \"#{long_message}\"",
+              "code" => "error(\"#{long_message}\")",
               "result" => ""
             })
 
@@ -517,12 +525,12 @@ defmodule Legion.ExecutorTest do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
         response(%{
           "action" => "eval_and_complete",
-          "code" => "%{summary: \"computed\", score: 42}",
+          "code" => "return {summary = \"computed\", score = 42}",
           "result" => ""
         })
       end)
 
-      assert {:ok, %{summary: "computed", score: 42}} =
+      assert {:ok, %{"summary" => "computed", "score" => 42}} =
                Legion.execute(StructuredOutputAgent, "compute")
     end
   end

--- a/test/legion/parallel_and_pipeline_test.exs
+++ b/test/legion/parallel_and_pipeline_test.exs
@@ -54,7 +54,7 @@ defmodule Legion.ParallelAndPipelineTest do
              id: "cancel",
              model: "test",
              context: nil,
-             object: %{"action" => "eval_and_continue", "code" => "1 + 1", "result" => ""}
+             object: %{"action" => "eval_and_continue", "code" => "return 1 + 1", "result" => ""}
            }}
         end
       end)
@@ -134,7 +134,7 @@ defmodule Legion.ParallelAndPipelineTest do
            id: "cancel",
            model: "test",
            context: nil,
-           object: %{"action" => "eval_and_continue", "code" => "1 + 1", "result" => ""}
+           object: %{"action" => "eval_and_continue", "code" => "return 1 + 1", "result" => ""}
          }}
       end)
 


### PR DESCRIPTION
Agents now write Lua by default; set `sandbox: Legion.Sandbox.Elixir` (per agent or globally) to keep Elixir.

- Mocked tests now feed Lua snippets; tests asserting Elixir-specific binding shapes pin the Elixir sandbox explicitly
- Only `Legion.Tool` modules are callable from Lua - plain modules passed as tools (e.g. `Jason`) are reference-only there
- Unit suite and LLM integration tests pass under the Lua default