### PR TITLE
Improve performance of Lua table -> Elixir list mapping

### DIFF
--- a/lib/legion/sandbox/lua.ex
+++ b/lib/legion/sandbox/lua.ex
@@ -249,15 +249,18 @@ defmodule Legion.Sandbox.Lua do
   # resolve to their module atom; array-shaped tables (keys exactly 1..n)
   # become lists; the rest become maps.
   defp lua_to_elixir(table, module_refs) when is_list(table) do
+    map = Map.new(table)
+    size = map_size(map)
+
     cond do
       module = bridged_module(table, module_refs) ->
         module
 
-      Enum.map(table, &elem(&1, 0)) |> Enum.sort() == Enum.to_list(1..length(table)//1) ->
-        for {_index, value} <- table, do: lua_to_elixir(value, module_refs)
+      Enum.all?(1..size//1, &Map.has_key?(map, &1)) ->
+        for index <- 1..size//1, do: lua_to_elixir(map[index], module_refs)
 
       true ->
-        Map.new(table, fn {key, value} ->
+        Map.new(map, fn {key, value} ->
           {lua_to_elixir(key, module_refs), lua_to_elixir(value, module_refs)}
         end)
     end

--- a/test/legion/sandbox/lua_test.exs
+++ b/test/legion/sandbox/lua_test.exs
@@ -163,7 +163,7 @@ defmodule Legion.Sandbox.LuaTest do
     assert {:ok, {list, _}} = Lua.execute(code, 15_000, [ListTool])
 
     assert is_list(list)
-    assert length(list) == num_elements
+    assert list == Enum.to_list(1..num_elements)
   end
 
   test "tuple results become arrays" do


### PR DESCRIPTION
Switched to $\mathcal{O}(n)$ approach from $\mathcal{O}(n\log n)$

Keyword list is no longer sorted, we instead convert it to a `Map` first and then check if it contains all keys from `1..length(table)//1`.