### PR TITLE
Add usage field to [:legion, :llm, :request, :stop] event

### DIFF
--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -256,11 +256,11 @@ defmodule Legion.Executor do
     case extract_object(response) do
       {:ok, action} when is_map(action) ->
         messages = messages ++ [message(:assistant, Jason.encode!(action))]
-        {{:ok, action, messages, turn_usage}, %{object: action}}
+        {{:ok, action, messages, turn_usage}, %{object: action, usage: usage}}
 
       {:error, reason} ->
         {{:error, "LLM response object invalid: #{inspect(reason)}", turn_usage},
-         %{error: reason}}
+         %{error: reason, usage: usage}}
     end
   end
 

--- a/lib/legion/telemetry.ex
+++ b/lib/legion/telemetry.ex
@@ -40,6 +40,8 @@ defmodule Legion.Telemetry do
 
   - `[:legion, :llm, :request, :start | :stop | :exception]`
     - Metadata includes: `agent`, `agent_id`, `model`, `message_count`, `iteration`
+    - Stop adds: `object` or `error`, and `usage` (the string-keyed usage map
+      with its `"at"` timestamp, when a response was received)
 
   ## Sandbox Eval Events (spans)
 

--- a/test/legion/executor_test.exs
+++ b/test/legion/executor_test.exs
@@ -187,6 +187,78 @@ defmodule Legion.ExecutorTest do
                Legion.Executor.run(MathAgent, executor_messages("recover"), %{})
     end
 
+    test "emits normalized usage in LLM request stop telemetry" do
+      handler_id = "executor-llm-stop-#{System.unique_integer()}"
+
+      :telemetry.attach(
+        handler_id,
+        [:legion, :llm, :request, :stop],
+        fn event, _measurements, metadata, pid -> send(pid, {:telemetry, event, metadata}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+        {:ok,
+         %ReqLLM.Response{
+           id: "test",
+           model: "test",
+           context: nil,
+           object: %{"action" => "return", "code" => "", "result" => "42"},
+           usage: %{input_tokens: 12, output_tokens: 5}
+         }}
+      end)
+
+      before = System.system_time(:millisecond)
+
+      assert {:ok, "42", _messages, [], [_usage]} =
+               Legion.Executor.run(MathAgent, executor_messages("what is 42?"), %{})
+
+      assert_receive {:telemetry, [:legion, :llm, :request, :stop], metadata}
+
+      assert %{
+               object: %{"action" => "return"},
+               usage: %{"input_tokens" => 12, "output_tokens" => 5, "at" => timestamp}
+             } = metadata
+
+      assert timestamp in before..System.system_time(:millisecond)
+    end
+
+    test "emits usage in LLM request stop telemetry for an invalid response" do
+      handler_id = "executor-llm-stop-invalid-#{System.unique_integer()}"
+
+      :telemetry.attach(
+        handler_id,
+        [:legion, :llm, :request, :stop],
+        fn event, _measurements, metadata, pid -> send(pid, {:telemetry, event, metadata}) end,
+        self()
+      )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      call_count = :counters.new(1, [:atomics])
+
+      stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+        :counters.add(call_count, 1, 1)
+
+        case :counters.get(call_count, 1) do
+          1 -> response(nil, 7)
+          2 -> response(%{"action" => "return", "code" => "", "result" => "recovered"}, 11)
+        end
+      end)
+
+      assert {:ok, "recovered", _messages, [], [_first, _second]} =
+               Legion.Executor.run(MathAgent, executor_messages("recover"), %{})
+
+      assert_receive {:telemetry, [:legion, :llm, :request, :stop], %{error: _, usage: usage}}
+      assert %{"turn_usage" => 7, "at" => at} = usage
+      assert is_integer(at)
+
+      assert_receive {:telemetry, [:legion, :llm, :request, :stop],
+                      %{object: %{"action" => "return"}, usage: %{"turn_usage" => 11}}}
+    end
+
     test "returns result for return action" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
         response(%{"action" => "return", "code" => "", "result" => "42"})


### PR DESCRIPTION
This PR extends the `[:legion, :llm, :request, :stop]` with usage data, which is needed inside [legion_web](https://github.com/software-mansion-labs/legion_web/pull/10). 

Extending the event here was deemed the cleaner solution, so that normalisation is centralised inside Legion instead of split between here and legion_web.