### PR TITLE
Rename key -> identity in RateLimiter context

### DIFF
--- a/lib/legion.ex
+++ b/lib/legion.ex
@@ -83,7 +83,7 @@ defmodule Legion do
       every agent, so you need only pass `:agent_id`. If a store is in effect but no
       `:agent_id` is given, Legion generates one - read it back with `get_agent_id/1`.
       An agent ID can belong to at most one live process across connected nodes.
-    - `:rate_limit` - a keyword list with `:limiter`, `:policy`, and `:key`
+    - `:rate_limit` - a keyword list with `:limiter`, `:policy`, and `:identity`
       (for example, `%{"ip" => "203.0.113.42"}`) that admits every turn through a
       `Legion.RateLimiter`. All three fields are required for a limit to apply,
       and each can be set globally instead. A refused turn returns `{:cancel,
@@ -105,7 +105,7 @@ defmodule Legion do
               max_agents: 10,
               max_tokens: 100_000
             },
-            key: %{"ip" => "203.0.113.42"}
+            identity: %{"ip" => "203.0.113.42"}
           ]
         )
   """

--- a/lib/legion/agent_server.ex
+++ b/lib/legion/agent_server.ex
@@ -89,7 +89,7 @@ defmodule Legion.AgentServer do
       %{
         limiter: nil,
         policy: nil,
-        key: nil
+        identity: nil
       }
       |> Map.merge(Map.new(Application.get_env(:legion, :rate_limit, [])))
       |> Map.merge(Vault.get(:rate_limit) || %{})
@@ -272,13 +272,13 @@ defmodule Legion.AgentServer do
              rate_limit: %{
                limiter: limiter,
                policy: policy,
-               key: key
+               identity: identity
              }
            }
          } = state
        )
-       when not is_nil(limiter) and not is_nil(policy) and not is_nil(key) do
-    :ok = limiter.enforce!(state.agent_id, key, policy)
+       when not is_nil(limiter) and not is_nil(policy) and not is_nil(identity) do
+    :ok = limiter.enforce!(state.agent_id, identity, policy)
     :ok
   rescue
     error in ExceededError ->
@@ -288,7 +288,7 @@ defmodule Legion.AgentServer do
         %{
           agent: state.agent_module,
           agent_id: state.agent_id,
-          key: error.key,
+          identity: error.identity,
           policy: error.policy,
           usage: error.usage,
           violations: error.violations

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -95,6 +95,10 @@ defmodule Legion.RateLimiter do
   error propagates, so an adapter that cannot reach its backing store fails
   the agent rather than silently admitting it.
   """
-  @callback enforce!(agent_id :: Store.agent_id(), identity :: limit_identity(), policy :: Policy.t()) ::
+  @callback enforce!(
+              agent_id :: Store.agent_id(),
+              identity :: limit_identity(),
+              policy :: Policy.t()
+            ) ::
               :ok | no_return()
 end

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -3,7 +3,7 @@ defmodule Legion.RateLimiter do
   Behaviour for enforcing rate limits across Legion agents.
 
   A rate limiter decides whether an agent may proceed under a `Policy`. Legion
-  calls `enforce!/3` for you: configure a limiter, a policy, and a key, and
+  calls `enforce!/3` for you: configure a limiter, a policy, and an identity, and
   every turn is admitted through it.
 
       Legion.start_link(ChatAgent,
@@ -14,7 +14,7 @@ defmodule Legion.RateLimiter do
             max_agents: 10,
             max_tokens: 100_000
           },
-          key: %{"ip" => "203.0.113.42"}
+          identity: %{"ip" => "203.0.113.42"}
         ]
       )
 
@@ -24,11 +24,11 @@ defmodule Legion.RateLimiter do
       config :legion, :rate_limit,
         limiter: MyApp.RateLimiter,
         policy: policy,
-        key: %{"ip" => "203.0.113.42"}
+        identity: %{"ip" => "203.0.113.42"}
 
   All three must be present for a limit to apply; leaving any of them `nil`
-  disables rate limiting. The `key` identifies the shared cohort: agents with
-  matching keys consume the same rolling-window limits. Each field in
+  disables rate limiting. An `identity` identifies the shared cohort: agents with
+  matching identities consume the same rolling-window limits. Each field in
   `:rate_limit` given to `Legion.start_link/2` wins over the application
   environment, and sub-agents inherit whatever their parent resolved unless
   given their own. Each sub-agent is a separate agent ID in the cohort, so it
@@ -70,7 +70,7 @@ defmodule Legion.RateLimiter do
         @behaviour Legion.RateLimiter
 
         @impl Legion.RateLimiter
-        def enforce!(agent_id, key, policy) do
+        def enforce!(agent_id, identity, policy) do
           # Check and record the rate-limit state for this adapter.
           :ok
         end
@@ -82,19 +82,19 @@ defmodule Legion.RateLimiter do
   alias Legion.RateLimiter.Policy
   alias Legion.Store
 
-  @type limit_key :: %{String.t() => any()}
+  @type limit_identity :: %{String.t() => any()}
 
   @doc """
-  Enforces `policy` for agents matching `key`.
+  Enforces `policy` for agents with a given `identity`.
 
   Returns `:ok` when the adapter admits the agent. The adapter defines how
-  keys match and how it stores rate-limit state.
+  identities match and how it stores rate-limit state.
 
   Raises `Legion.RateLimiter.ExceededError` when any configured limit has
   been reached. Legion catches that exception and cancels the turn; any other
   error propagates, so an adapter that cannot reach its backing store fails
   the agent rather than silently admitting it.
   """
-  @callback enforce!(agent_id :: Store.agent_id(), key :: limit_key(), policy :: Policy.t()) ::
+  @callback enforce!(agent_id :: Store.agent_id(), identity :: limit_identity(), policy :: Policy.t()) ::
               :ok | no_return()
 end

--- a/lib/legion/rate_limiter/exceeded_error.ex
+++ b/lib/legion/rate_limiter/exceeded_error.ex
@@ -1,8 +1,8 @@
 defmodule Legion.RateLimiter.ExceededError do
-  defexception [:agent_id, :key, :policy, :usage, :violations]
+  defexception [:agent_id, :identity, :policy, :usage, :violations]
 
   @impl Exception
-  def message(%__MODULE__{key: key, violations: violations}) do
-    "rate limit exceeded for #{inspect(key)}: #{inspect(violations)}"
+  def message(%__MODULE__{identity: identity, violations: violations}) do
+    "rate limit exceeded for #{inspect(identity)}: #{inspect(violations)}"
   end
 end

--- a/lib/legion/rate_limiter/postgres.ex
+++ b/lib/legion/rate_limiter/postgres.ex
@@ -34,7 +34,7 @@ defmodule Legion.RateLimiter.Postgres do
 
       :ok = MyApp.RateLimiter.enforce!(agent_id, %{"ip" => "203.0.113.42"}, policy)
 
-  Concurrent calls for the same key are serialized with a transaction-scoped
+  Concurrent calls for the same identity are serialized with a transaction-scoped
   advisory lock, so `:max_agents` holds under simultaneous admission. Rejected
   calls are rolled back, leaving metadata only for admitted calls.
 
@@ -42,13 +42,13 @@ defmodule Legion.RateLimiter.Postgres do
   never interrupted, so one turn can carry the recorded total past
   `:max_tokens` before the next call is refused.
 
-  ## Key matching
+  ## Identity matching
 
-  Keys are stored as JSON metadata and matched with Postgres JSON containment.
-  A broad key therefore includes metadata with additional fields. For example,
+  Identities are stored as JSON metadata and matched with Postgres JSON containment.
+  A broader identity therefore includes metadata with additional fields. For example,
   `%{"ip" => "203.0.113.42"}` matches an agent recorded with
   `%{"ip" => "203.0.113.42", "tenant" => "acme"}`. Calling `enforce!/3` again for
-  the same agent replaces its stored key while retaining its original start
+  the same agent replaces its stored identity while retaining its original start
   time.
 
   ## Limit evaluation
@@ -76,21 +76,21 @@ defmodule Legion.RateLimiter.Postgres do
   alias Legion.RateLimiter.Policy
 
   @doc false
-  def enforce!(repo, record, agent_id, rate_limit_key, %Policy{} = policy)
-      when is_binary(agent_id) and is_map(rate_limit_key) do
+  def enforce!(repo, record, agent_id, rate_limit_identity, %Policy{} = policy)
+      when is_binary(agent_id) and is_map(rate_limit_identity) do
     {:ok, :ok} =
       repo.transaction(fn ->
-        lock_key(repo, rate_limit_key)
-        upsert_metadata(repo, record, agent_id, rate_limit_key)
+        lock_identity(repo, rate_limit_identity)
+        upsert_metadata(repo, record, agent_id, rate_limit_identity)
 
-        usage = fetch_usage(repo, record, rate_limit_key, policy)
+        usage = fetch_usage(repo, record, rate_limit_identity, policy)
 
         violations = find_violations(usage, policy)
 
         if violations != [] do
           raise ExceededError,
             agent_id: agent_id,
-            key: rate_limit_key,
+            identity: rate_limit_identity,
             policy: policy,
             usage: usage,
             violations: violations
@@ -102,20 +102,20 @@ defmodule Legion.RateLimiter.Postgres do
     :ok
   end
 
-  def enforce!(_repo, _record, agent_id, key, policy) do
+  def enforce!(_repo, _record, agent_id, identity, policy) do
     raise ArgumentError,
           "invalid rate-limit arguments: " <>
-            "#{inspect(agent_id)}, #{inspect(key)}, #{inspect(policy)}"
+            "#{inspect(agent_id)}, #{inspect(identity)}, #{inspect(policy)}"
   end
 
-  # Serializes concurrent admissions for the same key so `:max_agents` counts
+  # Serializes concurrent admissions for the same identity so `:max_agents` counts
   # every in-flight transaction, not only those already committed.
-  defp lock_key(repo, metadata_key) do
-    repo.query!("SELECT pg_advisory_xact_lock(hashtext($1))", [Jason.encode!(metadata_key)])
+  defp lock_identity(repo, metadata_identity) do
+    repo.query!("SELECT pg_advisory_xact_lock(hashtext($1))", [Jason.encode!(metadata_identity)])
     :ok
   end
 
-  defp upsert_metadata(repo, record, agent_id, metadata_key) do
+  defp upsert_metadata(repo, record, agent_id, metadata_identity) do
     import Ecto.Query
 
     {_count, _} =
@@ -124,19 +124,19 @@ defmodule Legion.RateLimiter.Postgres do
         [
           %{
             agent_id: agent_id,
-            ratelimit_metadata: metadata_key,
+            ratelimit_metadata: metadata_identity,
             started_at: NaiveDateTime.utc_now()
           }
         ],
         conflict_target: :agent_id,
         on_conflict:
           from(agent in record,
-            update: [set: [ratelimit_metadata: ^metadata_key]],
+            update: [set: [ratelimit_metadata: ^metadata_identity]],
             where:
               fragment(
                 "? IS DISTINCT FROM ?",
                 agent.ratelimit_metadata,
-                type(^metadata_key, :map)
+                type(^metadata_identity, :map)
               )
           )
       )
@@ -144,18 +144,18 @@ defmodule Legion.RateLimiter.Postgres do
     :ok
   end
 
-  defp fetch_usage(repo, record, metadata_key, policy) do
+  defp fetch_usage(repo, record, metadata_identity, policy) do
     now = DateTime.utc_now()
 
     %{
-      agents: count_agents(repo, record, metadata_key, policy, now),
-      tokens: sum_tokens(repo, record, metadata_key, policy, now)
+      agents: count_agents(repo, record, metadata_identity, policy, now),
+      tokens: sum_tokens(repo, record, metadata_identity, policy, now)
     }
   end
 
-  defp count_agents(_repo, _record, _metadata_key, %{max_agents: nil}, _now), do: nil
+  defp count_agents(_repo, _record, _metadata_identity, %{max_agents: nil}, _now), do: nil
 
-  defp count_agents(repo, record, metadata_key, policy, now) do
+  defp count_agents(repo, record, metadata_identity, policy, now) do
     import Ecto.Query
 
     from(agent in record,
@@ -163,7 +163,7 @@ defmodule Legion.RateLimiter.Postgres do
         fragment(
           "? @> ?::jsonb",
           agent.ratelimit_metadata,
-          type(^metadata_key, :map)
+          type(^metadata_identity, :map)
         ),
       where: agent.started_at >= ^naive_cutoff(now, policy),
       select: count(agent.agent_id)
@@ -171,9 +171,9 @@ defmodule Legion.RateLimiter.Postgres do
     |> repo.one()
   end
 
-  defp sum_tokens(_repo, _record, _metadata_key, %{max_tokens: nil}, _now), do: nil
+  defp sum_tokens(_repo, _record, _metadata_identity, %{max_tokens: nil}, _now), do: nil
 
-  defp sum_tokens(repo, record, metadata_key, policy, now) do
+  defp sum_tokens(repo, record, metadata_identity, policy, now) do
     import Ecto.Query
 
     cutoff = DateTime.to_unix(now, :millisecond) - policy.interval_ms
@@ -185,7 +185,7 @@ defmodule Legion.RateLimiter.Postgres do
         fragment(
           "? @> ?::jsonb",
           agent.ratelimit_metadata,
-          type(^metadata_key, :map)
+          type(^metadata_identity, :map)
         ),
       where: fragment("(?->>'at')::bigint >= ?", field(entry, :value), ^cutoff),
       where: agent.updated_at >= ^naive_cutoff(now, policy),
@@ -239,12 +239,12 @@ defmodule Legion.RateLimiter.Postgres do
       end
 
       @impl Legion.RateLimiter
-      def enforce!(agent_id, key, policy) do
+      def enforce!(agent_id, identity, policy) do
         RateLimiter.Postgres.enforce!(
           unquote(repo),
           Record,
           agent_id,
-          key,
+          identity,
           policy
         )
       end

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -1471,7 +1471,8 @@ defmodule Legion.AgentServerTest do
     test "cancels the turn when the limiter rejects it" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
+      {:ok, pid} =
+        Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
 
       assert {:cancel, {:rate_limited, [:max_agents]}} = Legion.call(pid, "hi")
     end
@@ -1504,7 +1505,8 @@ defmodule Legion.AgentServerTest do
     test "runs the turn when no limiter is configured" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
+      {:ok, pid} =
+        Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
 
       assert {:ok, "ok"} = Legion.call(pid, "hi")
       refute_receive {:enforced, _, _, _}
@@ -1536,7 +1538,9 @@ defmodule Legion.AgentServerTest do
 
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
+      {:ok, pid} =
+        Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
+
       agent_id = Legion.get_agent_id(pid)
 
       {:cancel, _} = Legion.call(pid, "hi")
@@ -1594,7 +1598,8 @@ defmodule Legion.AgentServerTest do
 
       on_exit(fn -> Application.delete_env(:legion, :rate_limit) end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
+      {:ok, pid} =
+        Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
 
       assert {:cancel, {:rate_limited, [:max_agents]}} = Legion.call(pid, "hi")
     end

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -11,17 +11,17 @@ defmodule Legion.AgentServerTest do
   alias ReqLLM.Message.ContentPart
 
   defmodule TestRateLimiter do
-    @moduledoc "Limiter whose verdict and observer both travel in the key."
+    @moduledoc "Limiter whose verdict and observer both travel in the identity."
     @behaviour Legion.RateLimiter
 
     @impl Legion.RateLimiter
-    def enforce!(agent_id, key, policy) do
-      if pid = key[:report_to], do: send(pid, {:enforced, agent_id, key, policy})
+    def enforce!(agent_id, identity, policy) do
+      if pid = identity[:report_to], do: send(pid, {:enforced, agent_id, identity, policy})
 
-      if key[:verdict] == :reject do
+      if identity[:verdict] == :reject do
         raise ExceededError,
           agent_id: agent_id,
-          key: key,
+          identity: identity,
           policy: policy,
           usage: %{agents: 3, tokens: nil},
           violations: [:max_agents]
@@ -1447,8 +1447,8 @@ defmodule Legion.AgentServerTest do
     end
   end
 
-  defp allowing_key(test_pid), do: %{report_to: test_pid}
-  defp rejecting_key(test_pid), do: %{report_to: test_pid, verdict: :reject}
+  defp allowing_identity(test_pid), do: %{report_to: test_pid}
+  defp rejecting_identity(test_pid), do: %{report_to: test_pid, verdict: :reject}
 
   defp limit_policy, do: %Policy{interval_ms: 60_000, max_agents: 2}
 
@@ -1471,7 +1471,7 @@ defmodule Legion.AgentServerTest do
     test "cancels the turn when the limiter rejects it" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [key: rejecting_key(self())]))
+      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
 
       assert {:cancel, {:rate_limited, [:max_agents]}} = Legion.call(pid, "hi")
     end
@@ -1488,7 +1488,7 @@ defmodule Legion.AgentServerTest do
         Legion.start_link(
           MathAgent,
           limited(
-            rate_limit: [key: rejecting_key(self())],
+            rate_limit: [identity: rejecting_identity(self())],
             store: MemoryStore,
             agent_id: "rejected"
           )
@@ -1504,13 +1504,13 @@ defmodule Legion.AgentServerTest do
     test "runs the turn when no limiter is configured" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [key: rejecting_key(self())])
+      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
 
       assert {:ok, "ok"} = Legion.call(pid, "hi")
       refute_receive {:enforced, _, _, _}
     end
 
-    test "runs the turn when a limiter is configured without a policy or key" do
+    test "runs the turn when a limiter is configured without a policy or identity" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
       {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [limiter: TestRateLimiter])
@@ -1536,7 +1536,7 @@ defmodule Legion.AgentServerTest do
 
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [key: rejecting_key(self())]))
+      {:ok, pid} = Legion.start_link(MathAgent, limited(rate_limit: [identity: rejecting_identity(self())]))
       agent_id = Legion.get_agent_id(pid)
 
       {:cancel, _} = Legion.call(pid, "hi")
@@ -1548,8 +1548,8 @@ defmodule Legion.AgentServerTest do
       assert metadata.policy == limit_policy()
     end
 
-    test "sub-agents inherit the limiter, its policy, and its key" do
-      key = allowing_key(self())
+    test "sub-agents inherit the limiter, its policy, and its identity" do
+      identity = allowing_identity(self())
 
       stub(ReqLLM, :generate_object, fn _model, messages, _schema ->
         if Enum.any?(messages, &(&1[:role] == "assistant")) do
@@ -1562,14 +1562,14 @@ defmodule Legion.AgentServerTest do
         end
       end)
 
-      {:ok, pid} = Legion.start_link(DelegatingAgent, limited(rate_limit: [key: key]))
+      {:ok, pid} = Legion.start_link(DelegatingAgent, limited(rate_limit: [identity: identity]))
       parent_id = Legion.get_agent_id(pid)
       policy = limit_policy()
 
       {:ok, _} = Legion.call(pid, "delegate")
 
-      assert_receive {:enforced, ^parent_id, ^key, ^policy}
-      assert_receive {:enforced, child_id, ^key, ^policy}
+      assert_receive {:enforced, ^parent_id, ^identity, ^policy}
+      assert_receive {:enforced, child_id, ^identity, ^policy}
       assert child_id != parent_id
     end
 
@@ -1580,13 +1580,13 @@ defmodule Legion.AgentServerTest do
           rate_limit: [
             limiter: TestRateLimiter,
             policy: %Policy{interval_ms: 0},
-            key: allowing_key(self())
+            identity: allowing_identity(self())
           ]
         )
       end
     end
 
-    test "merges an agent key with application rate-limit defaults" do
+    test "merges an agent identity with application rate-limit defaults" do
       Application.put_env(:legion, :rate_limit,
         limiter: TestRateLimiter,
         policy: limit_policy()
@@ -1594,7 +1594,7 @@ defmodule Legion.AgentServerTest do
 
       on_exit(fn -> Application.delete_env(:legion, :rate_limit) end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [key: rejecting_key(self())])
+      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [identity: rejecting_identity(self())])
 
       assert {:cancel, {:rate_limited, [:max_agents]}} = Legion.call(pid, "hi")
     end


### PR DESCRIPTION
This PR is a just a rename: key became identity in the context of rate limiting 