### PR TITLE
Align Legion docs with README

### DIFF
--- a/lib/legion.ex
+++ b/lib/legion.ex
@@ -25,7 +25,7 @@ defmodule Legion do
         def start(_type, _args) do
           children = [
             MyApp.Repo,
-            {Legion, []}
+            Legion
           ]
 
           Supervisor.start_link(children, strategy: :one_for_one, name: MyApp.Supervisor)


### PR DESCRIPTION
The only change in this PR is in the `legion.ex` doc.

Before:
```elixir
children = [
  MyApp.Repo,
  {Legion, []}
]
```

After:
```elixir
children = [
  MyApp.Repo,
  Legion
]
```

Both work, they mean the same thing, the latter is cleaner. Same change is applied in #25 