### PR TITLE
Persist Lua bindings as plain user globals instead of the VM state

### DIFF
--- a/lib/legion/sandbox.ex
+++ b/lib/legion/sandbox.ex
@@ -31,7 +31,8 @@ defmodule Legion.Sandbox do
   ## Bindings
 
   `bindings` is an opaque, serialisable term owned by the sandbox: a keyword
-  list for `Legion.Sandbox.Elixir`, a `Lua` state for `Legion.Sandbox.Lua`.
+  list for `Legion.Sandbox.Elixir`, a list of `{name, value}` pairs of user
+  globals for `Legion.Sandbox.Lua`.
   `[]` always means "fresh state". The executor threads it between
   executions and persists it in checkpoints without inspecting it beyond
   `c:binding_names/1`.

--- a/lib/legion/sandbox/lua.ex
+++ b/lib/legion/sandbox/lua.ex
@@ -43,6 +43,9 @@ defmodule Legion.Sandbox.Lua do
 
   alias Legion.Sandbox.Runner
   alias Lua.VM.Limits
+  alias Lua.VM.State
+
+  import Lua.API, only: [is_table: 1, is_lua_func: 1, is_erl_func: 1, is_userdata: 1]
 
   require EEx
 
@@ -53,42 +56,6 @@ defmodule Legion.Sandbox.Lua do
   # Defined by `use Legion.Tool`, not part of a tool's callable surface.
   @tool_meta_functions [description: 0, extra_allowed_modules: 0]
 
-  # Copies the user's globals out of the VM as plain data. Done in Lua, where
-  # `type` tells data from functions, userdata, and threads - those are
-  # dropped, as are cycles. Names the fresh VM already defines (stdlib, tools)
-  # arrive in `__legion_baseline`, set right before this runs and never
-  # visible to the evaluated code.
-  @export_globals """
-  local skip = {__legion_baseline = true}
-  for _, name in ipairs(__legion_baseline) do skip[name] = true end
-
-  local function copy(value, seen)
-    local kind = type(value)
-    if kind == "table" then
-      if seen[value] then return nil end
-      seen[value] = true
-      local result = {}
-      for key, item in pairs(value) do
-        local copied_key, copied_item = copy(key, seen), copy(item, seen)
-        if copied_key ~= nil and copied_item ~= nil then result[copied_key] = copied_item end
-      end
-      seen[value] = nil
-      return result
-    elseif kind == "function" or kind == "userdata" or kind == "thread" then
-      return nil
-    end
-    return value
-  end
-
-  local globals = {}
-  for name, value in pairs(_G) do
-    if not skip[name] then globals[name] = copy(value, {}) end
-  end
-  return globals
-  """
-
-  # Field stamped on every bridged tool table so the table itself can stand in
-  # for its Elixir module when passed back through a bridge.
   @module_key "__module"
 
   @impl Legion.Sandbox
@@ -125,7 +92,7 @@ defmodule Legion.Sandbox.Lua do
   end
 
   @doc """
-  Evaluates Lua `code` in a sandboxed process.
+  Evaluates Lua code in a sandboxed process.
 
   `timeout_ms` controls the maximum execution time (`:infinity` to disable).
   `tools` are Elixir modules bridged in as global Lua tables. `limits` bound
@@ -174,35 +141,43 @@ defmodule Legion.Sandbox.Lua do
     |> register_tools(tools)
   end
 
-  # Bindings never carry the VM. Its state is a bag of closures over module
-  # code (every stdlib function included) that go stale on redeploy, it keeps
-  # every table ever allocated because the VM has no GC, and it would keep a
-  # tool callable after the tool was removed from the agent. So every
-  # evaluation builds a fresh VM with the current tools and copies the user's
-  # globals in as plain data. Names the fresh VM already defines are skipped,
-  # so a tool added since the bindings were written wins over a stale global.
   defp restore(lua, bindings, baseline) do
     for {name, value} <- bindings, name not in baseline, reduce: lua do
       lua -> Lua.set!(lua, [name], elixir_to_lua(value))
     end
   end
 
-  # `__module` tables are kept as tables (no `module_refs`), so a stored tool
-  # reference resolves against the tools of whichever run reads it back.
+  # Copies the user's globals out of the VM as plain data - functions,
+  # userdata, and cycles are dropped. `__module` tables are kept as tables (no
+  # `module_refs`), so a stored tool reference resolves against the tools of
+  # whichever run reads it back.
   defp export(lua, baseline) do
-    {[globals], _lua} =
-      lua
-      |> Lua.set!(["__legion_baseline"], baseline)
-      |> Lua.eval!(@export_globals)
+    globals =
+      for {name, value} <- State.globals(lua.state),
+          name not in baseline,
+          do: {name, Lua.decode!(lua, value)}
 
-    for {name, value} <- globals, do: {name, lua_to_elixir(value, %{})}
+    for {name, value} <- plain(globals), do: {name, lua_to_elixir(value, %{})}
   end
 
-  # A single string is capped below the heap budget so a string bomb is
-  # refused by the VM before allocating - a catchable "resulting string too
-  # large" error the model can react to - instead of racing the heap kill
-  # mid-allocation. Half the budget leaves room for the eval's other live
-  # data.
+  # A bare table reference is what `Lua.get!` leaves where a table contains
+  # itself.
+  defp plain(value)
+       when is_table(value) or is_lua_func(value) or is_erl_func(value) or is_userdata(value),
+       do: nil
+
+  defp plain(table) when is_list(table) do
+    Enum.flat_map(table, fn {key, item} ->
+      case {plain(key), plain(item)} do
+        {nil, _item} -> []
+        {_key, nil} -> []
+        pair -> [pair]
+      end
+    end)
+  end
+
+  defp plain(other), do: other
+
   defp new_vm(:infinity), do: Lua.new()
 
   defp new_vm(max_heap_bytes),
@@ -279,16 +254,7 @@ defmodule Legion.Sandbox.Lua do
     end
   end
 
-  defp global_names(lua) do
-    {[names], _lua} =
-      Lua.eval!(lua, """
-      local names = {}
-      for name in pairs(_G) do names[#names + 1] = name end
-      return names
-      """)
-
-    for {_index, name} <- names, do: name
-  end
+  defp global_names(lua), do: Map.keys(State.globals(lua.state))
 
   # Decoded Lua values -> Elixir. Tables carrying the bridge's module marker
   # resolve to their module atom; array-shaped tables (keys exactly 1..n)
@@ -320,8 +286,12 @@ defmodule Legion.Sandbox.Lua do
     end
   end
 
-  # Elixir values -> something the VM can encode. Tuples and structs have no
+  # Elixir values -> value the VM can encode. Tuples and structs have no
   # Lua counterpart: tuples become arrays, structs lose their module.
+  # Functions are dropped: the VM would bridge any 1- or 2-arity fun as a
+  # callable, handing sandboxed code whatever a tool result happens to carry
+  defp elixir_to_lua(fun) when is_function(fun), do: nil
+
   defp elixir_to_lua(%_{} = struct), do: struct |> Map.from_struct() |> elixir_to_lua()
 
   defp elixir_to_lua(map) when is_map(map),

--- a/lib/legion/sandbox/lua.ex
+++ b/lib/legion/sandbox/lua.ex
@@ -16,8 +16,10 @@ defmodule Legion.Sandbox.Lua do
     become maps, or lists when array-shaped) and results are encoded back
     (tuples become arrays, structs become tables of fields, atoms become
     strings).
-  - **Bindings** - the opaque `Lua` state. Lua globals persist across
-    executions that share bindings; `local` variables do not.
+  - **Bindings** - the user-defined globals, as a list of `{name, value}`
+    pairs of plain Elixir data (tables become maps, or lists when
+    array-shaped). Globals persist across executions that share bindings;
+    `local` variables, functions, and metatables do not.
   - **Blocked** - `io`, `file`, `os.execute/exit/getenv/...`, `require`,
     `load`, `print`, and `debug` are sandboxed and raise when called.
   - **Timeout and resource limits** - evaluation runs through
@@ -29,8 +31,8 @@ defmodule Legion.Sandbox.Lua do
 
       iex> {:ok, {4, _}} = Legion.Sandbox.Lua.execute("return 2 + 2", 5_000)
 
-      iex> {:ok, {nil, bindings}} = Legion.Sandbox.Lua.execute("x = 40", 5_000)
-      iex> {:ok, {42, _}} = Legion.Sandbox.Lua.execute("return x + 2", 5_000, [], bindings)
+      iex> {:ok, {nil, [{"x", 40}]}} = Legion.Sandbox.Lua.execute("x = 40", 5_000)
+      iex> {:ok, {42, _}} = Legion.Sandbox.Lua.execute("return x + 2", 5_000, [], [{"x", 40}])
 
       iex> {:error, message} = Legion.Sandbox.Lua.execute("os.getenv('HOME')", 5_000)
       iex> message =~ "sandboxed"
@@ -51,7 +53,39 @@ defmodule Legion.Sandbox.Lua do
   # Defined by `use Legion.Tool`, not part of a tool's callable surface.
   @tool_meta_functions [description: 0, extra_allowed_modules: 0]
 
-  @baseline_globals_key :legion_baseline_globals
+  # Copies the user's globals out of the VM as plain data. Done in Lua, where
+  # `type` tells data from functions, userdata, and threads - those are
+  # dropped, as are cycles. Names the fresh VM already defines (stdlib, tools)
+  # arrive in `__legion_baseline`, set right before this runs and never
+  # visible to the evaluated code.
+  @export_globals """
+  local skip = {__legion_baseline = true}
+  for _, name in ipairs(__legion_baseline) do skip[name] = true end
+
+  local function copy(value, seen)
+    local kind = type(value)
+    if kind == "table" then
+      if seen[value] then return nil end
+      seen[value] = true
+      local result = {}
+      for key, item in pairs(value) do
+        local copied_key, copied_item = copy(key, seen), copy(item, seen)
+        if copied_key ~= nil and copied_item ~= nil then result[copied_key] = copied_item end
+      end
+      seen[value] = nil
+      return result
+    elseif kind == "function" or kind == "userdata" or kind == "thread" then
+      return nil
+    end
+    return value
+  end
+
+  local globals = {}
+  for name, value in pairs(_G) do
+    if not skip[name] then globals[name] = copy(value, {}) end
+  end
+  return globals
+  """
 
   # Field stamped on every bridged tool table so the table itself can stand in
   # for its Elixir module when passed back through a bridge.
@@ -78,12 +112,7 @@ defmodule Legion.Sandbox.Lua do
   end
 
   @impl Legion.Sandbox
-  def binding_names(%Lua{} = lua) do
-    baseline = Lua.get_private!(lua, @baseline_globals_key)
-    global_names(lua) -- baseline
-  end
-
-  def binding_names(_fresh), do: []
+  def binding_names(bindings), do: for({name, _value} <- bindings, do: name)
 
   @impl Legion.Sandbox
   def prompt_info do
@@ -103,8 +132,8 @@ defmodule Legion.Sandbox.Lua do
   the evaluating process - see `Legion.Sandbox.Runner.run/3`.
 
   Returns `{:ok, {result, bindings}}` where `result` is the chunk's `return`
-  value (`nil` when it returns nothing) and `bindings` is the Lua state to
-  pass to subsequent calls, or `{:error, reason}`.
+  value (`nil` when it returns nothing) and `bindings` holds the user-defined
+  globals to pass to subsequent calls, or `{:error, reason}`.
   """
   @impl Legion.Sandbox
   def execute(code, timeout_ms, tools \\ [], bindings \\ [], limits \\ [])
@@ -116,16 +145,12 @@ defmodule Legion.Sandbox.Lua do
   end
 
   defp eval(code, tools, bindings, max_heap_bytes) do
-    lua = if bindings == [], do: init(tools, max_heap_bytes), else: refresh(bindings, tools)
+    lua = init(tools, max_heap_bytes)
+    baseline = global_names(lua)
+    lua = restore(lua, bindings, baseline)
     module_refs = module_refs(tools)
 
     {results, lua} = Lua.eval!(lua, code)
-
-    # The VM has no state garbage collector, so dead tables from every
-    # evaluation accumulate in the state - and in every persisted snapshot of
-    # it - for the life of the conversation. luerl's :luerl.gc/1 sweep covered
-    # this before the lua 1.0 backend switch; restore one when upstream ships
-    # a GC.
 
     value =
       case results do
@@ -134,7 +159,7 @@ defmodule Legion.Sandbox.Lua do
         many -> Enum.map(many, &lua_to_elixir(&1, module_refs))
       end
 
-    {:ok, {value, lua}}
+    {:ok, {value, export(lua, baseline)}}
   rescue
     e in [Lua.RuntimeException, Lua.CompilerException] -> {:error, Exception.message(e)}
   catch
@@ -143,46 +168,41 @@ defmodule Legion.Sandbox.Lua do
   end
 
   defp init(tools, max_heap_bytes) do
-    lua =
-      new_vm(max_heap_bytes)
-      |> Lua.sandbox([:print])
-      |> Lua.sandbox([:debug])
-      |> register_tools(tools)
-
-    Lua.put_private(lua, @baseline_globals_key, global_names(lua))
+    new_vm(max_heap_bytes)
+    |> Lua.sandbox([:print])
+    |> Lua.sandbox([:debug])
+    |> register_tools(tools)
   end
 
-  # The guards and tool bridges installed above are closures over module code.
-  # A state restored from before a deploy still carries the old ones - calling
-  # them raises :badfun once the defining module changed - and a tool added to
-  # the agent since the state was created was never bridged at all. Reinstall
-  # them on every reused state so long-lived conversations survive code
-  # changes, and fold the tool names into the baseline so a newly bridged tool
-  # is not reported to the model as a user-defined variable.
-  defp refresh(lua, tools) do
-    lua =
-      lua
-      |> Lua.sandbox([:print])
-      |> Lua.sandbox([:debug])
-      |> register_tools(tools)
-
-    short_names = for tool <- tools, do: tool |> Module.split() |> List.last()
-
-    case Lua.get_private(lua, @baseline_globals_key) do
-      {:ok, baseline} ->
-        Lua.put_private(lua, @baseline_globals_key, Enum.uniq(baseline ++ short_names))
-
-      :error ->
-        Lua.put_private(lua, @baseline_globals_key, global_names(lua))
+  # Bindings never carry the VM. Its state is a bag of closures over module
+  # code (every stdlib function included) that go stale on redeploy, it keeps
+  # every table ever allocated because the VM has no GC, and it would keep a
+  # tool callable after the tool was removed from the agent. So every
+  # evaluation builds a fresh VM with the current tools and copies the user's
+  # globals in as plain data. Names the fresh VM already defines are skipped,
+  # so a tool added since the bindings were written wins over a stale global.
+  defp restore(lua, bindings, baseline) do
+    for {name, value} <- bindings, name not in baseline, reduce: lua do
+      lua -> Lua.set!(lua, [name], elixir_to_lua(value))
     end
+  end
+
+  # `__module` tables are kept as tables (no `module_refs`), so a stored tool
+  # reference resolves against the tools of whichever run reads it back.
+  defp export(lua, baseline) do
+    {[globals], _lua} =
+      lua
+      |> Lua.set!(["__legion_baseline"], baseline)
+      |> Lua.eval!(@export_globals)
+
+    for {name, value} <- globals, do: {name, lua_to_elixir(value, %{})}
   end
 
   # A single string is capped below the heap budget so a string bomb is
   # refused by the VM before allocating - a catchable "resulting string too
   # large" error the model can react to - instead of racing the heap kill
   # mid-allocation. Half the budget leaves room for the eval's other live
-  # data. Baked into the state at init, so a conversation revived under a
-  # changed `max_heap` keeps the ceiling it started with.
+  # data.
   defp new_vm(:infinity), do: Lua.new()
 
   defp new_vm(max_heap_bytes),

--- a/lib/legion/sandbox/lua/constraints.eex
+++ b/lib/legion/sandbox/lua/constraints.eex
@@ -1,5 +1,5 @@
 - End your code with `return <expression>` to produce a result. A bare expression on its own line is a Lua **syntax error** - write `return planner_result`, not `planner_result`.
-- Assign to global variables (no `local`) for values you need in later executions - only globals persist between runs.
+- Assign to global variables (no `local`) for values you need in later executions - only global data (strings, numbers, booleans, tables) persists between runs. Functions do not, so define any helper in every execution that uses it.
 - `print`, `io`, `os.getenv`, `require`, and `load` are not available - return values from your code instead of printing them.
 - Tools are Elixir functions bridged into Lua. Arguments you pass are converted: Lua tables become maps (or lists when array-shaped). Results are converted back: maps and structs become tables, Elixir tuples and lists become arrays (1-indexed), atoms become strings (`:ok` arrives as `"ok"`).
 - Where a tool expects an Elixir module reference (for example `AgentTool.call(PlannerAgent, task)`), pass the tool's global table directly by its short name - it is converted to the module automatically.

--- a/test/legion/sandbox/lua_bindings_end_to_end_test.exs
+++ b/test/legion/sandbox/lua_bindings_end_to_end_test.exs
@@ -1,0 +1,228 @@
+defmodule Legion.Sandbox.LuaBindingsEndToEndTest.CatalogTool do
+  use Legion.Tool
+
+  def description, do: "CatalogTool - a catalog of talks."
+
+  @doc "Every talk in the catalog, with nested tags and speaker."
+  def talks do
+    for id <- 1..300 do
+      %{id: id, title: "Talk #{id}", tags: ["lua", "elixir"], speaker: %{name: "Speaker #{id}"}}
+    end
+  end
+
+  @doc "Reports how a value passed from Lua arrives in Elixir."
+  def describe(value), do: %{module: is_atom(value), inspected: inspect(value)}
+end
+
+defmodule Legion.Sandbox.LuaBindingsEndToEndTest.AdminTool do
+  use Legion.Tool
+
+  def description, do: "AdminTool - privileged operations, reports every call to the test."
+
+  def wipe(marker) do
+    send(:lua_bindings_end_to_end_test, {:admin_reached, marker})
+    "wiped #{marker}"
+  end
+end
+
+defmodule Legion.Sandbox.LuaBindingsEndToEndTest do
+  @moduledoc """
+  Drives a conversation-scoped Lua agent through the whole stack - scripted
+  LLM, bridged tools, the Postgres store, restarts - and checks what the
+  persisted bindings carry across each boundary.
+  """
+  use ExUnit.Case, async: false
+  use Mimic
+
+  alias Legion.Sandbox.LuaBindingsEndToEndTest.AdminTool
+  alias Legion.Sandbox.LuaBindingsEndToEndTest.CatalogTool
+  alias Legion.Store.Payload
+  alias Legion.Test.Support.PostgresRepo, as: Repo
+
+  @moduletag capture_log: true
+
+  defmodule CuratorAgent do
+    @moduledoc "Curates the talk catalog and may run privileged admin operations."
+    use Legion.Agent
+
+    def tools, do: [CatalogTool, AdminTool]
+    def config, do: %{binding_scope: :conversation}
+  end
+
+  defmodule RestrictedCuratorAgent do
+    @moduledoc "The same agent after AdminTool was taken away."
+    use Legion.Agent
+
+    def tools, do: [CatalogTool]
+    def config, do: %{binding_scope: :conversation}
+  end
+
+  defmodule Store do
+    use Legion.Store.Postgres, repo: Legion.Test.Support.PostgresRepo
+  end
+
+  setup :set_mimic_global
+
+  setup do
+    Repo.query!("TRUNCATE legion_agents", [])
+    Process.register(self(), :lua_bindings_end_to_end_test)
+    :ok
+  end
+
+  test "globals survive a restart as plain data; dead tool results and functions do not" do
+    {:ok, pid} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-restart")
+
+    assert {:ok, 100} =
+             evaluate(pid, """
+             local talks = CatalogTool.talks()
+             favorites = {}
+             for _, talk in ipairs(talks) do
+               if talk.id % 3 == 0 then table.insert(favorites, talk) end
+             end
+             count = #favorites
+             function summarize() return count end
+             return count
+             """)
+
+    # The model is told which variables it can rely on next time.
+    %{content: content} =
+      pid |> Legion.get_messages() |> Enum.filter(&(&1.type == :eval_result)) |> List.last()
+
+    assert content =~ "Available variables:"
+    assert content =~ "`count`"
+    assert content =~ "`favorites`"
+    refute content =~ "`summarize`"
+    refute content =~ "`talks`"
+
+    # The store holds exactly the two user globals - none of the 300 talks the
+    # model dropped, no Lua function, and nothing that references host code.
+    assert {:ok, %Payload{conversation_state: state}} = Store.get("curator-restart")
+    assert [{"count", 100}, {"favorites", favorites}] = Enum.sort(state.bindings)
+    assert length(favorites) == 100
+
+    assert hd(favorites) == %{
+             "id" => 3,
+             "title" => "Talk 3",
+             "tags" => ["lua", "elixir"],
+             "speaker" => %{"name" => "Speaker 3"}
+           }
+
+    refute holds_function?(state)
+
+    GenServer.stop(pid)
+    {:ok, revived} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-restart")
+
+    assert {:ok, %{"count" => 100, "first" => "Talk 3", "summarize" => "nil"}} =
+             evaluate(revived, """
+             return {count = count, first = favorites[1].title, summarize = type(summarize)}
+             """)
+  end
+
+  test "a tool removed between restarts is unreachable, even when the model stashed it" do
+    {:ok, pid} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-revoked")
+
+    assert {:ok, "wiped before"} =
+             evaluate(pid, """
+             admin = AdminTool.wipe
+             admin_ref = AdminTool
+             catalog = CatalogTool
+             return admin("before")
+             """)
+
+    assert_receive {:admin_reached, "before"}
+
+    # Tool references persist as their marker table; the stashed bridge does not.
+    assert {:ok, %Payload{conversation_state: %{bindings: bindings}}} =
+             Store.get("curator-revoked")
+
+    assert Enum.sort(bindings) == [
+             {"admin_ref", %{"__module" => Atom.to_string(AdminTool)}},
+             {"catalog", %{"__module" => Atom.to_string(CatalogTool)}}
+           ]
+
+    GenServer.stop(pid)
+
+    {:ok, restricted} =
+      Legion.start_link(RestrictedCuratorAgent, store: Store, agent_id: "curator-revoked")
+
+    # A reference to a tool the agent still has resolves to the module; one to
+    # the revoked tool stays an inert table.
+    catalog_name = inspect(CatalogTool)
+
+    assert {:ok,
+            %{
+              "admin" => "nil",
+              "admin_tool" => "nil",
+              "admin_ref" => %{"module" => false},
+              "catalog" => %{"module" => true, "inspected" => ^catalog_name}
+            }} =
+             evaluate(restricted, """
+             return {
+               admin = type(admin),
+               admin_tool = type(AdminTool),
+               admin_ref = CatalogTool.describe(admin_ref),
+               catalog = CatalogTool.describe(catalog),
+             }
+             """)
+
+    refute_received {:admin_reached, _marker}
+  end
+
+  test "a global shadowing a tool name does not break later evaluations or restarts" do
+    {:ok, pid} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-shadow")
+
+    assert {:ok, 1} = evaluate(pid, "CatalogTool = 1\nreturn CatalogTool")
+    assert {:ok, %Payload{conversation_state: %{bindings: []}}} = Store.get("curator-shadow")
+    assert {:ok, 300} = evaluate(pid, "return #CatalogTool.talks()")
+
+    GenServer.stop(pid)
+    {:ok, revived} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-shadow")
+
+    assert {:ok, 300} = evaluate(revived, "return #CatalogTool.talks()")
+  end
+
+  test "functions do not persist between evaluations within a turn, data does" do
+    {:ok, pid} = Legion.start_link(CuratorAgent, store: Store, agent_id: "curator-turn")
+
+    assert {:ok, %{"helper" => "nil", "count" => 1}} =
+             evaluate(pid, [
+               "function helper() return 1 end\ncount = 1",
+               "return {helper = type(helper), count = count}"
+             ])
+  end
+
+  # One turn: the scripted LLM answers the n-th request with the n-th chunk -
+  # `eval_and_continue` for all but the last, which is `eval_and_complete`.
+  defp evaluate(pid, code) when is_binary(code), do: evaluate(pid, [code])
+
+  defp evaluate(pid, chunks) do
+    requests = :counters.new(1, [:atomics])
+
+    stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+      :counters.add(requests, 1, 1)
+      index = :counters.get(requests, 1)
+      action = if index == length(chunks), do: "eval_and_complete", else: "eval_and_continue"
+
+      {:ok,
+       %ReqLLM.Response{
+         id: "test",
+         model: "test",
+         context: nil,
+         object: %{"action" => action, "code" => Enum.at(chunks, index - 1), "result" => ""},
+         usage: %{turn_usage: 0}
+       }}
+    end)
+
+    Legion.call(pid, Enum.join(chunks, "\n"))
+  end
+
+  defp holds_function?(term) when is_function(term), do: true
+  defp holds_function?(%_{} = struct), do: struct |> Map.from_struct() |> holds_function?()
+  defp holds_function?(map) when is_map(map), do: map |> Map.to_list() |> holds_function?()
+  defp holds_function?(list) when is_list(list), do: Enum.any?(list, &holds_function?/1)
+
+  defp holds_function?(tuple) when is_tuple(tuple),
+    do: tuple |> Tuple.to_list() |> holds_function?()
+
+  defp holds_function?(_other), do: false
+end

--- a/test/legion/sandbox/lua_test.exs
+++ b/test/legion/sandbox/lua_test.exs
@@ -84,6 +84,43 @@ defmodule Legion.Sandbox.LuaTest do
     assert Lua.binding_names([]) == []
   end
 
+  test "bindings are plain data: functions and dead tables are not carried" do
+    code = """
+    count = 1
+    items = {1, {x = 2}}
+    local dead = {1, 2, 3}
+    function helper() return 1 end
+    saved = EchoTool.add
+    """
+
+    {:ok, {nil, bindings}} = Lua.execute(code, 15_000, [EchoTool])
+
+    assert Enum.sort(bindings) == [{"count", 1}, {"items", [1, %{"x" => 2}]}]
+    assert {:ok, {2, _}} = Lua.execute("return items[2].x", 15_000, [EchoTool], bindings)
+  end
+
+  test "a tool removed from the agent is unreachable from restored bindings" do
+    {:ok, {nil, bindings}} = Lua.execute("saved = EchoTool.add", 15_000, [EchoTool])
+
+    assert {:ok, {nil, _}} = Lua.execute("return saved", 15_000, [], bindings)
+    assert {:error, message} = Lua.execute("return EchoTool.add(1, 2)", 15_000, [], bindings)
+    assert message =~ "attempt to index a nil value"
+  end
+
+  test "a stored tool reference resolves against the tools of the run that reads it" do
+    {:ok, {nil, bindings}} = Lua.execute("planner = EchoTool", 15_000, [EchoTool])
+
+    assert {:ok, {%{"is_atom" => true}, _}} =
+             Lua.execute("return EchoTool.module_check(planner)", 15_000, [EchoTool], bindings)
+  end
+
+  test "a global named after a tool does not break later evaluations" do
+    {:ok, {nil, bindings}} = Lua.execute("EchoTool = 1", 15_000, [EchoTool])
+
+    assert {:ok, {3, _}} =
+             Lua.execute("return EchoTool.add(1, 2)", 15_000, [EchoTool], bindings)
+  end
+
   test "parse errors are caught by check" do
     assert {:error, message} = Lua.execute("local x =;", 15_000)
     assert message =~ "Failed to compile Lua!"

--- a/test/legion/sandbox/lua_test.exs
+++ b/test/legion/sandbox/lua_test.exs
@@ -8,6 +8,7 @@ defmodule Legion.Sandbox.LuaTest.EchoTool do
   def shape(value), do: %{received: value, tag: :ok}
   def module_check(module), do: %{is_atom: is_atom(module), name: inspect(module)}
   def pair, do: {:ok, 42}
+  def host_fun, do: %{name: "reader", read: fn path -> {:host_called, path} end}
   def boom, do: raise(ArgumentError, "tool exploded")
   def throw_it, do: throw(:tool_escaped)
   def exit_it, do: exit(:tool_exited)
@@ -84,10 +85,13 @@ defmodule Legion.Sandbox.LuaTest do
     assert Lua.binding_names([]) == []
   end
 
-  test "bindings are plain data: functions and dead tables are not carried" do
+  test "bindings are plain data: functions, cycles, and dead tables are not carried" do
     code = """
     count = 1
+    flag = false
     items = {1, {x = 2}}
+    cyclic = {}
+    cyclic.self = cyclic
     local dead = {1, 2, 3}
     function helper() return 1 end
     saved = EchoTool.add
@@ -95,8 +99,15 @@ defmodule Legion.Sandbox.LuaTest do
 
     {:ok, {nil, bindings}} = Lua.execute(code, 15_000, [EchoTool])
 
-    assert Enum.sort(bindings) == [{"count", 1}, {"items", [1, %{"x" => 2}]}]
+    assert Enum.sort(bindings) ==
+             [{"count", 1}, {"cyclic", []}, {"flag", false}, {"items", [1, %{"x" => 2}]}]
+
     assert {:ok, {2, _}} = Lua.execute("return items[2].x", 15_000, [EchoTool], bindings)
+  end
+
+  test "rebinding _G does not affect which globals are exported" do
+    assert {:ok, {nil, [{"x", 1}]}} = Lua.execute("_G = nil\nx = 1", 15_000)
+    assert {:ok, {nil, [{"y", 2}]}} = Lua.execute("_G = {evil = 1}\ny = 2", 15_000)
   end
 
   test "a tool removed from the agent is unreachable from restored bindings" do
@@ -205,6 +216,18 @@ defmodule Legion.Sandbox.LuaTest do
 
   test "tuple results become arrays" do
     assert {:ok, {["ok", 42], _}} = Lua.execute("return EchoTool.pair()", 15_000, [EchoTool])
+  end
+
+  test "elixir functions in tool results and bindings are dropped, not bridged" do
+    assert {:ok, {%{"name" => "reader"}, _}} =
+             Lua.execute("return EchoTool.host_fun()", 15_000, [EchoTool])
+
+    assert {:error, message} =
+             Lua.execute("return EchoTool.host_fun().read('/etc/hosts')", 15_000, [EchoTool])
+
+    assert message =~ "attempt to call a nil value"
+
+    assert {:ok, {nil, _}} = Lua.execute("return p", 15_000, [], [{"p", fn _ -> :host end}])
   end
 
   test "tool exceptions surface with the tool name" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,7 +1,5 @@
 Mimic.copy(ReqLLM)
 
-Legion.Telemetry.attach_default_logger()
-
 defmodule Legion.Test.Support.LegionAgentsMigration do
   use Ecto.Migration
 


### PR DESCRIPTION
Lua bindings were the `%Lua{}` VM state: tied to the `lua` library's internal struct layout, carrying bridge closures that went stale across deploys (hence `refresh/2`), and growing with every dead table since the VM has no GC.

Each eval now starts a fresh VM, and bindings are the user's globals exported as plain data - strings, numbers, booleans, and tables as maps/lists. Functions, userdata, and cycles are dropped on export and restore. A stored tool reference persists as its `__module` marker table and resolves only against the tools of the run that reads it, so a revoked tool is unreachable from old bindings. Elixir functions inside tool results are no longer bridged as Lua callables.

