### PR TITLE
Make RateLimiter.resolve!/1 raise on invalid configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Changes
+
+- Rate limiting - [`Legion.RateLimiter.resolve!/1`](https://hexdocs.pm/legion/Legion.RateLimiter.html#resolve!/1) raises when rules are given without a limiter, logs a warning when a limiter has no rules unless `rules: []` opts out explicitly, logs and ignores unknown `:rate_limit` keys instead of dropping them silently, and no longer accepts `rules:` in `config :legion, :rate_limit`
+
 ## v0.5.0 - 2026-09-01
 
 ### Changes

--- a/lib/legion.ex
+++ b/lib/legion.ex
@@ -97,8 +97,10 @@ defmodule Legion do
     - `:rate_limit` - a keyword list with `:limiter` and `:rules`, a list of
       `Legion.RateLimiter.Rule`s pairing an identity (for example,
       `%{"ip" => "203.0.113.42"}`) with a policy, checked for every turn by a
-      `Legion.RateLimiter`. Both are required for a limit to apply; the limiter
-      and a default policy can be set globally. A denied turn returns
+      `Legion.RateLimiter`. The limiter and a default policy can be set
+      globally; rules are given here. Rules without a limiter raise, and a
+      limiter without rules runs the agent without rate limiting and logs a
+      warning unless `rules: []` opts out on purpose. A denied turn returns
       `{:cancel, {:rate_limited, violations}}`; see `Legion.RateLimiter`.
     - Any config overrides (`:model`, `:max_iterations`, etc.)
 

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -54,13 +54,16 @@ defmodule Legion.RateLimiter do
         rate_limit: [rules: [%Legion.RateLimiter.Rule{identity: %{"ip" => "203.0.113.42"}}]]
       )
 
-  A rule given without a `:policy` takes the default one. Rate limiting applies
-  only when a limiter and at least one rule resolve; a limiter without rules,
-  or rules without a limiter, disables it. Sub-agents inherit whatever their
-  parent resolved and cannot override it - a parent started without rate
-  limiting runs its whole subtree without it, even when the application
-  configures rules globally. Each sub-agent is a separate agent ID in every
-  group, so it counts towards `:max_agents` and its usage towards
+  A rule given without a `:policy` takes the default one. Rules belong to the
+  call site: the application config accepts  `:limiter` and `:default_policy`.
+  Rate limiting applies only when a limiter and at least  one rule resolve.
+  Rules without a limiter raise. A limiter without rules runs  the agent without
+  rate limiting and logs a warning - pass `rules: []` to opt  out on purpose
+  and silence it. Unknown keys in either place are logged and ignored.
+  Sub-agents inherit whatever their parent resolved - a parent started
+  without rate limiting runs its whole subtree without it, and rules given
+  below it raise rather than re-enable it. Each sub-agent is a separate agent
+  ID in every group, so it counts towards `:max_agents` and its usage towards
   `:max_tokens`.
 
   Rules must agree on their identities: two rules may share a field only with
@@ -121,6 +124,8 @@ defmodule Legion.RateLimiter do
   deny the call as a unit. See `Legion.RateLimiter.Rule`,
   `Legion.RateLimiter.Policy`, and `Legion.RateLimiter.Postgres`.
   """
+  require Logger
+
   alias Legion.RateLimiter.Rule
   alias Legion.Store
 
@@ -146,6 +151,8 @@ defmodule Legion.RateLimiter do
               :ok | no_return()
 
   @off %{limiter: nil, rules: []}
+  @override_keys [:limiter, :rules]
+  @app_config_keys [:limiter, :default_policy]
 
   @doc """
   Resolves the limiter and rules to enforce.
@@ -161,15 +168,17 @@ defmodule Legion.RateLimiter do
   policy that is present is used as is; missing fields are not filled in.
 
   Returns `%{limiter: module | nil, rules: [Legion.RateLimiter.Rule.t()]}`.
-  A `nil` limiter or an empty rule list means rate limiting is off; both keys
-  are then reset, so the result is always a complete map.
+  With no limiter and no rules the result is `%{limiter: nil, rules: []}`,
+  meaning rate limiting is off. A limiter without rules resolves to the same
+  and logs a warning, unless `overrides` gives `rules: []` explicitly.
 
-  Raises `ArgumentError` when `overrides` is not `nil` or a keyword list,
-  carries keys other than `:limiter` and `:rules`, `:rules` is not a list of
-  `Legion.RateLimiter.Rule` structs, a rule fails
-  `Legion.RateLimiter.Rule.validate!/1`, or two rules give one identity key
-  different values. The application's `:rate_limit` config is held to the
-  same keys plus `:default_policy`.
+  Raises `ArgumentError` when `overrides` is not `nil` or a keyword list, when
+  rules are given without a limiter, when `:rules` is not a list of
+  `Legion.RateLimiter.Rule` structs, when a rule fails
+  `Legion.RateLimiter.Rule.validate!/1`, or when two rules give one identity
+  key different values. Keys other than `:limiter` and `:rules` in
+  `overrides`, or other than `:limiter` and `:default_policy` in the
+  application config, are logged and ignored.
 
   ## Examples
 
@@ -183,12 +192,13 @@ defmodule Legion.RateLimiter do
   def resolve!(nil), do: resolve!([])
 
   def resolve!(overrides) when is_list(overrides) do
-    overrides = Keyword.validate!(overrides, [:limiter, :rules])
+    overrides = known_keys!(overrides, @override_keys, ":rate_limit")
 
     app_config =
-      Keyword.validate!(
+      known_keys!(
         Application.get_env(:legion, :rate_limit, []),
-        [:limiter, :rules, :default_policy]
+        @app_config_keys,
+        "config :legion, :rate_limit"
       )
 
     overrides = fill_policies(overrides, Keyword.get(app_config, :default_policy))
@@ -197,7 +207,7 @@ defmodule Legion.RateLimiter do
     |> Map.merge(layer(app_config))
     |> Map.merge(layer(Vault.get(:rate_limit) || %{}))
     |> Map.merge(layer(overrides))
-    |> finish!()
+    |> finish!(Keyword.has_key?(overrides, :rules))
   end
 
   def resolve!(other) do
@@ -224,13 +234,53 @@ defmodule Legion.RateLimiter do
   defp fill(other, _default_policy),
     do: raise(ArgumentError, "expected a #{inspect(Rule)} in :rules, got: #{inspect(other)}")
 
-  defp layer(config), do: config |> Map.new() |> Map.take([:limiter, :rules])
+  defp known_keys!(config, allowed, source) do
+    unless Keyword.keyword?(config) do
+      raise ArgumentError, "expected #{source} to be a keyword list, got: #{inspect(config)}"
+    end
 
-  defp finish!(%{limiter: limiter, rules: rules}) do
+    {known, unknown} = Keyword.split(config, allowed)
+
+    if unknown != [] do
+      Logger.warning(
+        "#{source} ignores unknown keys #{inspect(Enum.uniq(Keyword.keys(unknown)))}; " <>
+          "allowed keys are #{inspect(allowed)}"
+      )
+    end
+
+    known
+  end
+
+  defp layer(config), do: config |> Map.new() |> Map.take(@override_keys)
+
+  defp finish!(%{limiter: limiter, rules: rules}, explicit_rules?) do
     Enum.each(rules, &Rule.validate!/1)
     validate_identities!(rules)
 
-    if is_nil(limiter) or rules == [], do: @off, else: %{limiter: limiter, rules: rules}
+    case {limiter, rules} do
+      {nil, []} ->
+        @off
+
+      {nil, _rules} ->
+        raise ArgumentError,
+              "rate-limit rules need a limiter - pass `limiter:`, set " <>
+                "`config :legion, :rate_limit, limiter: MyLimiter`, or drop the rules " <>
+                "when the parent agent runs without rate limiting"
+
+      {limiter, []} ->
+        unless explicit_rules? do
+          Logger.warning(
+            "#{inspect(limiter)} is configured but no rules were given, so this agent " <>
+              "runs without rate limiting; pass `rate_limit: [rules: [...]]`, or " <>
+              "`rate_limit: [rules: []]` to opt out on purpose"
+          )
+        end
+
+        @off
+
+      {limiter, rules} ->
+        %{limiter: limiter, rules: rules}
+    end
   end
 
   defp validate_identities!(rules) do

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -164,10 +164,12 @@ defmodule Legion.RateLimiter do
   A `nil` limiter or an empty rule list means rate limiting is off; both keys
   are then reset, so the result is always a complete map.
 
-  Raises `ArgumentError` when `:rules` is not a list of
+  Raises `ArgumentError` when `overrides` is not `nil` or a keyword list,
+  carries keys other than `:limiter` and `:rules`, `:rules` is not a list of
   `Legion.RateLimiter.Rule` structs, a rule fails
   `Legion.RateLimiter.Rule.validate!/1`, or two rules give one identity key
-  different values.
+  different values. The application's `:rate_limit` config is held to the
+  same keys plus `:default_policy`.
 
   ## Examples
 
@@ -181,7 +183,14 @@ defmodule Legion.RateLimiter do
   def resolve!(nil), do: resolve!([])
 
   def resolve!(overrides) when is_list(overrides) do
-    app_config = Application.get_env(:legion, :rate_limit, [])
+    overrides = Keyword.validate!(overrides, [:limiter, :rules])
+
+    app_config =
+      Keyword.validate!(
+        Application.get_env(:legion, :rate_limit, []),
+        [:limiter, :rules, :default_policy]
+      )
+
     overrides = fill_policies(overrides, Keyword.get(app_config, :default_policy))
 
     @off
@@ -189,6 +198,11 @@ defmodule Legion.RateLimiter do
     |> Map.merge(layer(Vault.get(:rate_limit) || %{}))
     |> Map.merge(layer(overrides))
     |> finish!()
+  end
+
+  def resolve!(other) do
+    raise ArgumentError,
+          "expected :rate_limit to be a keyword list or nil, got: #{inspect(other)}"
   end
 
   defp fill_policies(overrides, default_policy) do

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -55,10 +55,10 @@ defmodule Legion.RateLimiter do
       )
 
   A rule given without a `:policy` takes the default one. Rules belong to the
-  call site: the application config accepts  `:limiter` and `:default_policy`.
-  Rate limiting applies only when a limiter and at least  one rule resolve.
-  Rules without a limiter raise. A limiter without rules runs  the agent without
-  rate limiting and logs a warning - pass `rules: []` to opt  out on purpose
+  call site: the application config accepts `:limiter` and `:default_policy`.
+  Rate limiting applies only when a limiter and at least one rule resolve.
+  Rules without a limiter raise. A limiter without rules runs the agent without
+  rate limiting and logs a warning - pass `rules: []` to opt out on purpose
   and silence it. Unknown keys in either place are logged and ignored.
   Sub-agents inherit whatever their parent resolved - a parent started
   without rate limiting runs its whole subtree without it, and rules given
@@ -263,7 +263,7 @@ defmodule Legion.RateLimiter do
 
       {nil, _rules} ->
         raise ArgumentError,
-              "rate-limit rules need a limiter - pass `limiter:`, set " <>
+              "rate-limit rules need a limiter - pass `limiter: MyLimiter`, set " <>
                 "`config :legion, :rate_limit, limiter: MyLimiter`, or drop the rules " <>
                 "when the parent agent runs without rate limiting"
 
@@ -271,8 +271,8 @@ defmodule Legion.RateLimiter do
         unless explicit_rules? do
           Logger.warning(
             "#{inspect(limiter)} is configured but no rules were given, so this agent " <>
-              "runs without rate limiting; pass `rate_limit: [rules: [...]]`, or " <>
-              "`rate_limit: [rules: []]` to opt out on purpose"
+              "runs without rate limiting; pass `rules: [...]`, or `rules: []` to opt " <>
+              "out on purpose (as `rate_limit: [rules: ...]` when starting an agent)"
           )
         end
 

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -1568,21 +1568,22 @@ defmodule Legion.AgentServerTest do
       assert_receive {:enforced, _, ^rejecting, _}
     end
 
-    test "runs the turn when no limiter is configured" do
-      stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
-
-      {:ok, pid} =
+    test "refuses to start with rules but no limiter" do
+      assert_raise ArgumentError, ~r/rules need a limiter/, fn ->
         Legion.start_link(MathAgent, rate_limit: [rules: [rule(rejecting_identity(self()))]])
-
-      assert {:ok, "ok"} = Legion.call(pid, "hi")
-      refute_receive {:enforced, _, _, _}
+      end
     end
 
-    test "runs the turn when a limiter is configured without rules" do
+    test "runs the turn unlimited, with a warning, when a limiter is configured without rules" do
       stub(ReqLLM, :generate_object, fn _model, _messages, _schema -> llm_response("ok") end)
 
-      {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [limiter: TestRateLimiter])
+      {pid, log} =
+        with_log(fn ->
+          {:ok, pid} = Legion.start_link(MathAgent, rate_limit: [limiter: TestRateLimiter])
+          pid
+        end)
 
+      assert log =~ "runs without rate limiting"
       assert {:ok, "ok"} = Legion.call(pid, "hi")
       refute_receive {:enforced, _, _, _}
     end
@@ -1660,7 +1661,7 @@ defmodule Legion.AgentServerTest do
     test "sub-agents of a parent that opted out are not rate limited" do
       Application.put_env(:legion, :rate_limit,
         limiter: TestRateLimiter,
-        rules: [rule(rejecting_identity(self()))]
+        default_policy: limit_policy()
       )
 
       on_exit(fn -> Application.delete_env(:legion, :rate_limit) end)

--- a/test/legion/rate_limiter_test.exs
+++ b/test/legion/rate_limiter_test.exs
@@ -97,6 +97,32 @@ defmodule Legion.RateLimiterTest do
       end
     end
 
+    test "rejects overrides with keys other than :limiter and :rules" do
+      assert_raise ArgumentError,
+                   ~r/unknown keys \[:policy, :identity\].*allowed keys are: \[:limiter, :rules\]/,
+                   fn ->
+                     RateLimiter.resolve!(identity: @ip, policy: @policy)
+                   end
+    end
+
+    test "rejects overrides that are not a keyword list" do
+      assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
+        RateLimiter.resolve!([rule(@ip, @policy)])
+      end
+
+      assert_raise ArgumentError, ~r/expected :rate_limit to be a keyword list or nil/, fn ->
+        RateLimiter.resolve!(%{rules: [rule(@ip, @policy)]})
+      end
+    end
+
+    test "rejects application config with unknown keys" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter, policy: @policy)
+
+      assert_raise ArgumentError, ~r/unknown keys \[:policy\]/, fn ->
+        RateLimiter.resolve!(rules: [rule(@ip, @policy)])
+      end
+    end
+
     test "rejects a rule that is not a Rule struct" do
       assert_raise ArgumentError, ~r/expected a Legion\.RateLimiter\.Rule/, fn ->
         RateLimiter.resolve!(rules: [%{identity: @ip, policy: @policy}])

--- a/test/legion/rate_limiter_test.exs
+++ b/test/legion/rate_limiter_test.exs
@@ -1,6 +1,8 @@
 defmodule Legion.RateLimiterTest do
   use ExUnit.Case, async: false
 
+  import ExUnit.CaptureLog
+
   alias Legion.RateLimiter
   alias Legion.RateLimiter.Policy
   alias Legion.RateLimiter.Rule
@@ -66,15 +68,39 @@ defmodule Legion.RateLimiterTest do
       end
     end
 
-    test "resolves to no limit with rules but no limiter" do
-      assert RateLimiter.resolve!(rules: [rule(@ip, @policy)]) == @off
+    test "raises with rules but no limiter" do
+      assert_raise ArgumentError, ~r/rules need a limiter/, fn ->
+        RateLimiter.resolve!(rules: [rule(@ip, @policy)])
+      end
     end
 
-    test "resolves to no limit with a limiter but no rules" do
+    test "raises when a limiter given at start is nil next to rules" do
       Application.put_env(:legion, :rate_limit, limiter: Limiter)
 
-      assert RateLimiter.resolve!(nil) == @off
-      assert RateLimiter.resolve!(rules: []) == @off
+      assert_raise ArgumentError, ~r/rules need a limiter/, fn ->
+        RateLimiter.resolve!(limiter: nil, rules: [rule(@ip, @policy)])
+      end
+    end
+
+    test "resolves to no limit and warns with a limiter but no rules given" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter)
+
+      log =
+        capture_log(fn ->
+          assert RateLimiter.resolve!(nil) == @off
+          assert RateLimiter.resolve!([]) == @off
+          assert RateLimiter.resolve!(limiter: OtherLimiter) == @off
+        end)
+
+      assert log =~ "Legion.RateLimiterTest.Limiter is configured but no rules were given"
+      assert log =~ "Legion.RateLimiterTest.OtherLimiter is configured but no rules were given"
+      assert log =~ "runs without rate limiting"
+    end
+
+    test "resolves to no limit silently when opting out with empty rules" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter)
+
+      assert capture_log(fn -> assert RateLimiter.resolve!(rules: []) == @off end) == ""
     end
 
     test "validates rules even when no limiter is configured" do
@@ -97,16 +123,22 @@ defmodule Legion.RateLimiterTest do
       end
     end
 
-    test "rejects overrides with keys other than :limiter and :rules" do
-      assert_raise ArgumentError,
-                   ~r/unknown keys \[:policy, :identity\].*allowed keys are: \[:limiter, :rules\]/,
-                   fn ->
-                     RateLimiter.resolve!(identity: @ip, policy: @policy)
-                   end
+    test "warns about and ignores overrides keys other than :limiter and :rules" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter)
+
+      log =
+        capture_log(fn ->
+          assert RateLimiter.resolve!(identity: @ip, policy: @policy) == @off
+        end)
+
+      assert log =~ ":rate_limit ignores unknown keys [:identity, :policy]"
+      assert log =~ "allowed keys are [:limiter, :rules]"
+      # Dropping the stale keys leaves no rules, which is worth a second warning.
+      assert log =~ "runs without rate limiting"
     end
 
     test "rejects overrides that are not a keyword list" do
-      assert_raise ArgumentError, ~r/expected a keyword list/, fn ->
+      assert_raise ArgumentError, ~r/expected :rate_limit to be a keyword list/, fn ->
         RateLimiter.resolve!([rule(@ip, @policy)])
       end
 
@@ -115,12 +147,41 @@ defmodule Legion.RateLimiterTest do
       end
     end
 
-    test "rejects application config with unknown keys" do
+    test "warns about and ignores application config keys other than :limiter and :default_policy" do
       Application.put_env(:legion, :rate_limit, limiter: Limiter, policy: @policy)
 
-      assert_raise ArgumentError, ~r/unknown keys \[:policy\]/, fn ->
-        RateLimiter.resolve!(rules: [rule(@ip, @policy)])
-      end
+      log =
+        capture_log(fn ->
+          assert RateLimiter.resolve!(rules: [rule(@ip, @policy)]) ==
+                   %{limiter: Limiter, rules: [rule(@ip, @policy)]}
+        end)
+
+      assert log =~ "config :legion, :rate_limit ignores unknown keys [:policy]"
+      assert log =~ "allowed keys are [:limiter, :default_policy]"
+    end
+
+    test "does not take rules from the application config" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter, rules: [rule(@ip, @policy)])
+
+      log =
+        capture_log(fn ->
+          assert RateLimiter.resolve!(rules: [rule(@email, @narrow)]) ==
+                   %{limiter: Limiter, rules: [rule(@email, @narrow)]}
+
+          assert RateLimiter.resolve!(rules: []) == @off
+        end)
+
+      assert log =~ "config :legion, :rate_limit ignores unknown keys [:rules]"
+    end
+
+    test "rejects application config that is not a keyword list" do
+      Application.put_env(:legion, :rate_limit, %{limiter: Limiter})
+
+      assert_raise ArgumentError,
+                   ~r/expected config :legion, :rate_limit to be a keyword list/,
+                   fn ->
+                     RateLimiter.resolve!(nil)
+                   end
     end
 
     test "rejects a rule that is not a Rule struct" do
@@ -151,8 +212,8 @@ defmodule Legion.RateLimiterTest do
       assert RateLimiter.resolve!(nil) == inherited
     end
 
-    test "a sub-agent of a parent that opted out stays unlimited" do
-      Application.put_env(:legion, :rate_limit, limiter: Limiter, rules: [rule(%{}, @policy)])
+    test "a sub-agent of a parent that opted out stays unlimited without a warning" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter, default_policy: @policy)
 
       parent = RateLimiter.resolve!(rules: [])
       assert parent == @off
@@ -160,14 +221,24 @@ defmodule Legion.RateLimiterTest do
       # AgentServer.init stores the parent's verdict for sub-agents to inherit.
       Vault.unsafe_put(:rate_limit, parent)
 
-      assert RateLimiter.resolve!(nil) == @off
+      assert capture_log(fn -> assert RateLimiter.resolve!(nil) == @off end) == ""
     end
 
-    test "a sub-agent of a parent that opted out cannot re-enable the application rules" do
-      Application.put_env(:legion, :rate_limit, limiter: Limiter, rules: [rule(%{}, @policy)])
+    test "a limiter given below a parent that opted out does not re-enable rate limiting" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter, default_policy: @policy)
       Vault.unsafe_put(:rate_limit, @off)
 
-      assert RateLimiter.resolve!(limiter: OtherLimiter) == @off
+      log = capture_log(fn -> assert RateLimiter.resolve!(limiter: OtherLimiter) == @off end)
+      assert log =~ "runs without rate limiting"
+    end
+
+    test "rules given below a parent that opted out raise" do
+      Application.put_env(:legion, :rate_limit, limiter: Limiter, default_policy: @policy)
+      Vault.unsafe_put(:rate_limit, @off)
+
+      assert_raise ArgumentError, ~r/parent agent runs without rate limiting/, fn ->
+        RateLimiter.resolve!(rules: [rule(@ip, @policy)])
+      end
     end
 
     test "the parent's resolved configuration wins over the application environment" do


### PR DESCRIPTION
This PR adds validation to `RateLimiter.resolve!/1` to ensure wrong config options are not passed silently as no rate-limiting.