### PR TITLE
Add identity to Store

### DIFF
--- a/lib/legion/store/payload.ex
+++ b/lib/legion/store/payload.ex
@@ -19,7 +19,8 @@ defmodule Legion.Store.Payload do
     :status,
     :started_at,
     :conversation_state,
-    :usage
+    :usage,
+    :ratelimit_metadata
   ]
 
   @type status :: :idle | :running
@@ -43,6 +44,7 @@ defmodule Legion.Store.Payload do
           status: status() | nil,
           started_at: NaiveDateTime.t() | nil,
           conversation_state: state() | nil,
-          usage: [map()] | nil
+          usage: [map()] | nil,
+          ratelimit_metadata: map() | nil
         }
 end

--- a/lib/legion/store/postgres.ex
+++ b/lib/legion/store/postgres.ex
@@ -98,6 +98,7 @@ defmodule Legion.Store.Postgres do
           field :usage, {:array, :map}
           field :inserted_at, :naive_datetime_usec
           field :updated_at, :naive_datetime_usec
+          field :ratelimit_metadata, :map
         end
       end
 
@@ -197,7 +198,8 @@ defmodule Legion.Store.Postgres do
       status: decode_status(record.status),
       started_at: record.started_at,
       conversation_state: decode_conversation_state(record.conversation_state),
-      usage: record.usage
+      usage: record.usage,
+      ratelimit_metadata: record.ratelimit_metadata
     }
   end
 

--- a/test/legion/store/postgres_db_test.exs
+++ b/test/legion/store/postgres_db_test.exs
@@ -2,11 +2,17 @@ defmodule Legion.Store.PostgresDbTest do
   @moduledoc "Exercises the generated Postgres store against a real database."
   use ExUnit.Case, async: false
 
+  alias Legion.RateLimiter.Policy
+  alias Legion.RateLimiter.Rule
   alias Legion.Store.Payload
   alias Legion.Test.Support.PostgresRepo, as: Repo
 
   defmodule Store do
     use Legion.Store.Postgres, repo: Legion.Test.Support.PostgresRepo
+  end
+
+  defmodule RateLimiter do
+    use Legion.RateLimiter.Postgres, repo: Legion.Test.Support.PostgresRepo
   end
 
   setup do
@@ -51,6 +57,20 @@ defmodule Legion.Store.PostgresDbTest do
              ])
   end
 
+  test "exposes the rate limiter's metadata and keeps it across partial saves" do
+    identity = %{"ip" => "203.0.113.42", "tenant" => "acme"}
+    policy = %Policy{window_ms: 60_000, max_agents: 10}
+
+    assert :ok = RateLimiter.enforce!("limited", [%Rule{identity: identity, policy: policy}])
+    assert {:ok, %Payload{ratelimit_metadata: ^identity}} = Store.get("limited")
+
+    assert :ok = Store.save(%Payload{agent_id: "limited", status: :running})
+    assert {:ok, %Payload{status: :running, ratelimit_metadata: ^identity}} = Store.get("limited")
+
+    assert :ok = Store.save(%Payload{agent_id: "unlimited", status: :idle})
+    assert {:ok, %Payload{ratelimit_metadata: nil}} = Store.get("unlimited")
+  end
+
   test "save/1 fully inserts every payload field" do
     payload = %Payload{
       agent_id: "user_42",
@@ -63,7 +83,8 @@ defmodule Legion.Store.PostgresDbTest do
         bindings: [x: 42],
         executor_state: :nonexistent
       },
-      usage: [%{turn_usage: 100}]
+      usage: [%{turn_usage: 100}],
+      ratelimit_metadata: %{"ip" => "203.0.113.42", "tenant" => "acme"}
     }
 
     expected_payload = %{payload | usage: [%{"turn_usage" => 100}]}
@@ -99,7 +120,8 @@ defmodule Legion.Store.PostgresDbTest do
         bindings: [x: 42],
         executor_state: :nonexistent
       },
-      usage: [%{turn_usage: 100}]
+      usage: [%{turn_usage: 100}],
+      ratelimit_metadata: %{"ip" => "203.0.113.42"}
     }
 
     assert :ok = Store.save(initial)
@@ -121,7 +143,8 @@ defmodule Legion.Store.PostgresDbTest do
                 bindings: [x: 42],
                 executor_state: :nonexistent
               },
-              usage: [%{"turn_usage" => 100}]
+              usage: [%{"turn_usage" => 100}],
+              ratelimit_metadata: %{"ip" => "203.0.113.42"}
             }} = Store.get("user_42")
 
     %{rows: [[updated_at]]} =

--- a/test/legion/store/postgres_test.exs
+++ b/test/legion/store/postgres_test.exs
@@ -38,6 +38,7 @@ defmodule Legion.Store.PostgresTest do
         started_at: nil,
         conversation_state: nil,
         usage: [],
+        ratelimit_metadata: nil,
         inserted_at: nil,
         updated_at: nil
       }
@@ -76,7 +77,8 @@ defmodule Legion.Store.PostgresTest do
         bindings: [x: 42],
         executor_state: :nonexistent
       },
-      usage: [%{turn_usage: 100}]
+      usage: [%{turn_usage: 100}],
+      ratelimit_metadata: %{"ip" => "203.0.113.42"}
     }
 
     assert :ok = Store.save(payload)
@@ -129,7 +131,8 @@ defmodule Legion.Store.PostgresTest do
         bindings: [x: 42],
         executor_state: :nonexistent
       },
-      usage: [%{turn_usage: 100}]
+      usage: [%{turn_usage: 100}],
+      ratelimit_metadata: %{"ip" => "203.0.113.42"}
     }
 
     assert :ok = Store.save(initial)
@@ -148,7 +151,8 @@ defmodule Legion.Store.PostgresTest do
                 bindings: [x: 42],
                 executor_state: :nonexistent
               },
-              usage: [%{turn_usage: 100}]
+              usage: [%{turn_usage: 100}],
+              ratelimit_metadata: %{"ip" => "203.0.113.42"}
             }} = Store.get("user_42")
 
     assert NaiveDateTime.compare(FakeRepo.run("user_42").updated_at, previous_updated_at) == :gt


### PR DESCRIPTION
This PR adds `:ratelimit_metadata` field to `Legion.Store.Payload` so that legion_web can consume it. (See [PR #18](https://github.com/software-mansion-labs/legion_web/pull/18) on legion_web)