### PR TITLE
Add max_running_agents to the rate-limit policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changes
 
 - Rate limiting - [`Legion.RateLimiter.resolve!/1`](https://hexdocs.pm/legion/Legion.RateLimiter.html#resolve!/1) raises when rules are given without a limiter, logs a warning when a limiter has no rules unless `rules: []` opts out explicitly, logs and ignores unknown `:rate_limit` keys instead of dropping them silently, and no longer accepts `rules:` in `config :legion, :rate_limit`
+- Rate limiting - `:max_running_agents` in [`Legion.RateLimiter.Policy`](https://hexdocs.pm/legion/Legion.RateLimiter.Policy.html) caps matching agents mid-turn at once; the Postgres adapter counts live agents and marks the caller running inside its transaction
 
 ## v0.5.0 - 2026-09-01
 

--- a/lib/legion/rate_limiter.ex
+++ b/lib/legion/rate_limiter.ex
@@ -63,7 +63,8 @@ defmodule Legion.RateLimiter do
   Sub-agents inherit whatever their parent resolved - a parent started
   without rate limiting runs its whole subtree without it, and rules given
   below it raise rather than re-enable it. Each sub-agent is a separate agent
-  ID in every group, so it counts towards `:max_agents` and its usage towards
+  ID in every group, so it counts towards `:max_agents`, towards
+  `:max_running_agents` while its turn runs, and its usage towards
   `:max_tokens`.
 
   Rules must agree on their identities: two rules may share a field only with

--- a/lib/legion/rate_limiter/policy.ex
+++ b/lib/legion/rate_limiter/policy.ex
@@ -3,12 +3,13 @@ defmodule Legion.RateLimiter.Policy do
   Defines the limits enforced by a `Legion.RateLimiter`.
 
   Every policy has a rolling `:window_ms`. Within that window, it can
-  limit new agents matching an identity, recorded token usage
-  for those agents, or both:
+  limit new agents matching an identity, how many of them run a turn at
+  once, recorded token usage for those agents, or any combination:
 
       %Legion.RateLimiter.Policy{
         window_ms: :timer.minutes(1),
         max_agents: 10,
+        max_running_agents: 2,
         max_tokens: 100_000
       }
 
@@ -19,23 +20,28 @@ defmodule Legion.RateLimiter.Policy do
     * `:max_agents` - maximum number of matching agent IDs started during the
       window, including sub-agents. `0` allows no agents; `nil` disables this
       limit.
+    * `:max_running_agents` - maximum number of matching agents mid-turn at
+      the same time, including sub-agents. A turn's usage is recorded only
+      when it ends, so this is the limit that bounds how far one window can
+      overshoot `:max_tokens`. `0` allows no turns; `nil` disables this limit.
     * `:max_tokens` - maximum recorded token total for matching agents during
       the window. Limits are checked when a turn starts and never interrupt
       a running turn, so one turn can carry the recorded total past the
       maximum before the next one is denied. `0` accepts no tokens and so
       denies every turn; `nil` disables this limit.
 
-  A policy with both optional limits set to `nil` is unrestricted. See
+  A policy with every optional limit set to `nil` is unrestricted. See
   `Legion.RateLimiter` for the adapter interface and
   `Legion.RateLimiter.Postgres` for the bundled implementation.
   """
 
   @enforce_keys [:window_ms]
-  defstruct [:window_ms, :max_agents, :max_tokens]
+  defstruct [:window_ms, :max_agents, :max_running_agents, :max_tokens]
 
   @type t :: %__MODULE__{
           window_ms: pos_integer(),
           max_agents: non_neg_integer() | nil,
+          max_running_agents: non_neg_integer() | nil,
           max_tokens: non_neg_integer() | nil
         }
 
@@ -49,6 +55,7 @@ defmodule Legion.RateLimiter.Policy do
   def validate!(%__MODULE__{} = policy) do
     validate_window!(policy.window_ms)
     validate_limit!(:max_agents, policy.max_agents)
+    validate_limit!(:max_running_agents, policy.max_running_agents)
     validate_limit!(:max_tokens, policy.max_tokens)
 
     :ok

--- a/lib/legion/rate_limiter/postgres.ex
+++ b/lib/legion/rate_limiter/postgres.ex
@@ -59,13 +59,22 @@ defmodule Legion.RateLimiter.Postgres do
   field. Rules passed directly to `enforce!/2` must agree on shared fields;
   `Legion.start_link/2` validates this, and the adapter does not. Calling
   `enforce!/2` again for the same agent replaces its stored metadata while
-  retaining its original start time.
+  retaining its original start time, and marks it `running` when a rule
+  limits running agents.
 
   ## Limit evaluation
 
   The adapter includes the agent being checked when it evaluates
   `:max_agents`, so it raises only when that call would make the matching count
   exceed the configured maximum. Agents are counted by `started_at`.
+
+  `:max_running_agents` counts the matching agents mid-turn: rows whose stored
+  status is `running`, changed inside the window, and whose agent process is
+  alive. A turn interrupted by a crash never writes `idle` back, so a dead
+  process does not hold a slot. When a rule sets this limit, the adapter marks
+  the caller `running` in the same transaction, before it counts, so
+  concurrent starts see each other; the caller's own row is included, as with
+  `:max_agents`.
 
   `:max_tokens` is evaluated from recorded `"total_tokens"` usage whose `"at"`
   timestamp falls inside the policy's window; once that total reaches the
@@ -88,6 +97,7 @@ defmodule Legion.RateLimiter.Postgres do
   @doc false
   def enforce!(repo, record, agent_id, rules) when is_binary(agent_id) and is_list(rules) do
     metadata = Enum.reduce(rules, %{}, &Map.merge(&2, &1.identity))
+    mark_running? = Enum.any?(rules, &(&1.policy.max_running_agents != nil))
 
     {:ok, :ok} =
       repo.transaction(fn ->
@@ -97,7 +107,7 @@ defmodule Legion.RateLimiter.Postgres do
         |> Enum.uniq()
         |> Enum.each(&lock_identity(repo, &1))
 
-        upsert_metadata(repo, record, agent_id, metadata)
+        upsert_metadata(repo, record, agent_id, metadata, mark_running?)
 
         Enum.each(rules, fn %Rule{identity: identity, policy: policy} ->
           usage = fetch_usage(repo, record, identity, policy)
@@ -131,31 +141,38 @@ defmodule Legion.RateLimiter.Postgres do
     :ok
   end
 
-  defp upsert_metadata(repo, record, agent_id, metadata_identity) do
+  # A running limit needs the caller's turn visible to the counts that follow
+  # in this transaction, so the row is marked before the lock is released.
+  # Without one the row is only touched when its identity changed.
+  defp upsert_metadata(repo, record, agent_id, metadata_identity, mark_running?) do
     import Ecto.Query
 
+    now = NaiveDateTime.utc_now()
+    row = %{agent_id: agent_id, ratelimit_metadata: metadata_identity, started_at: now}
+
+    {row, on_conflict} =
+      if mark_running? do
+        {Map.merge(row, %{status: "running", updated_at: now}),
+         from(agent in record,
+           update: [
+             set: [ratelimit_metadata: ^metadata_identity, status: "running", updated_at: ^now]
+           ]
+         )}
+      else
+        {row,
+         from(agent in record,
+           update: [set: [ratelimit_metadata: ^metadata_identity]],
+           where:
+             fragment(
+               "? IS DISTINCT FROM ?",
+               agent.ratelimit_metadata,
+               type(^metadata_identity, :map)
+             )
+         )}
+      end
+
     {_count, _} =
-      repo.insert_all(
-        record,
-        [
-          %{
-            agent_id: agent_id,
-            ratelimit_metadata: metadata_identity,
-            started_at: NaiveDateTime.utc_now()
-          }
-        ],
-        conflict_target: :agent_id,
-        on_conflict:
-          from(agent in record,
-            update: [set: [ratelimit_metadata: ^metadata_identity]],
-            where:
-              fragment(
-                "? IS DISTINCT FROM ?",
-                agent.ratelimit_metadata,
-                type(^metadata_identity, :map)
-              )
-          )
-      )
+      repo.insert_all(record, [row], conflict_target: :agent_id, on_conflict: on_conflict)
 
     :ok
   end
@@ -165,6 +182,7 @@ defmodule Legion.RateLimiter.Postgres do
 
     %{
       agents: count_agents(repo, record, metadata_identity, policy, now),
+      running: count_running(repo, record, metadata_identity, policy, now),
       tokens: sum_tokens(repo, record, metadata_identity, policy, now)
     }
   end
@@ -185,6 +203,36 @@ defmodule Legion.RateLimiter.Postgres do
       select: count(agent.agent_id)
     )
     |> repo.one()
+  end
+
+  defp count_running(_repo, _record, _metadata_identity, %{max_running_agents: nil}, _now),
+    do: nil
+
+  # The stored status is a hint: an agent killed mid-turn never writes `idle`
+  # back, so only rows whose process is still alive count.
+  defp count_running(repo, record, metadata_identity, policy, now) do
+    import Ecto.Query
+
+    from(agent in record,
+      where:
+        fragment(
+          "? @> ?::jsonb",
+          agent.ratelimit_metadata,
+          type(^metadata_identity, :map)
+        ),
+      where: agent.status == "running",
+      where: agent.updated_at >= ^naive_cutoff(now, policy),
+      select: agent.agent_id
+    )
+    |> repo.all()
+    |> Enum.count(&live?/1)
+  end
+
+  defp live?(agent_id) do
+    case Legion.lookup(agent_id) do
+      {:ok, pid} -> Legion.running?(pid)
+      :error -> false
+    end
   end
 
   defp sum_tokens(_repo, _record, _metadata_identity, %{max_tokens: nil}, _now), do: nil
@@ -220,11 +268,12 @@ defmodule Legion.RateLimiter.Postgres do
     |> DateTime.to_naive()
   end
 
-  # The agent count includes the caller's own row, hence `>`; tokens are
+  # The agent counts include the caller's own row, hence `>`; tokens are
   # consumed before this check, hence `>=`.
   defp find_violations(usage, policy) do
     for {name, true} <- %{
           max_agents: usage.agents != nil and usage.agents > policy.max_agents,
+          max_running_agents: usage.running != nil and usage.running > policy.max_running_agents,
           max_tokens: usage.tokens != nil and usage.tokens >= policy.max_tokens
         },
         do: name
@@ -247,6 +296,7 @@ defmodule Legion.RateLimiter.Postgres do
         @primary_key {:agent_id, :string, autogenerate: false}
 
         schema unquote(table) do
+          field :status, :string
           field :started_at, :naive_datetime_usec
           field :usage, {:array, :map}
           field :updated_at, :naive_datetime_usec

--- a/lib/legion/rate_limiter/postgres.ex
+++ b/lib/legion/rate_limiter/postgres.ex
@@ -141,9 +141,6 @@ defmodule Legion.RateLimiter.Postgres do
     :ok
   end
 
-  # A running limit needs the caller's turn visible to the counts that follow
-  # in this transaction, so the row is marked before the lock is released.
-  # Without one the row is only touched when its identity changed.
   defp upsert_metadata(repo, record, agent_id, metadata_identity, mark_running?) do
     import Ecto.Query
 
@@ -208,8 +205,6 @@ defmodule Legion.RateLimiter.Postgres do
   defp count_running(_repo, _record, _metadata_identity, %{max_running_agents: nil}, _now),
     do: nil
 
-  # The stored status is a hint: an agent killed mid-turn never writes `idle`
-  # back, so only rows whose process is still alive count.
   defp count_running(repo, record, metadata_identity, policy, now) do
     import Ecto.Query
 

--- a/test/legion/rate_limiter/policy_test.exs
+++ b/test/legion/rate_limiter/policy_test.exs
@@ -4,8 +4,14 @@ defmodule Legion.RateLimiter.PolicyTest do
   alias Legion.RateLimiter.Policy
 
   describe "validate!/1" do
-    test "accepts a policy with both limits set" do
-      assert :ok = Policy.validate!(%Policy{window_ms: 1_000, max_agents: 1, max_tokens: 10})
+    test "accepts a policy with every limit set" do
+      assert :ok =
+               Policy.validate!(%Policy{
+                 window_ms: 1_000,
+                 max_agents: 1,
+                 max_running_agents: 1,
+                 max_tokens: 10
+               })
     end
 
     test "accepts an unrestricted policy" do
@@ -31,6 +37,12 @@ defmodule Legion.RateLimiter.PolicyTest do
     test "rejects a non-integer limit" do
       assert_raise ArgumentError, ~r/:max_tokens/, fn ->
         Policy.validate!(%Policy{window_ms: 1_000, max_tokens: "10"})
+      end
+    end
+
+    test "rejects a negative running-agents limit" do
+      assert_raise ArgumentError, ~r/:max_running_agents/, fn ->
+        Policy.validate!(%Policy{window_ms: 1_000, max_running_agents: -1})
       end
     end
 

--- a/test/legion/rate_limiter/postgres_db_test.exs
+++ b/test/legion/rate_limiter/postgres_db_test.exs
@@ -337,6 +337,101 @@ defmodule Legion.RateLimiter.PostgresDbTest do
     assert recorded == Enum.count(outcomes, &(&1 == :ok))
   end
 
+  describe "max_running_agents" do
+    test "allows exactly max_running_agents live agents mid-turn" do
+      rules = [rule(@ip_key, policy(max_running_agents: 2))]
+      for agent_id <- ~w(running-1 running-2 running-3), do: start_live_agent(agent_id)
+
+      assert :ok = RateLimiter.enforce!("running-1", rules)
+      assert :ok = RateLimiter.enforce!("running-2", rules)
+
+      error = assert_raise(ExceededError, fn -> RateLimiter.enforce!("running-3", rules) end)
+      assert error.violations == [:max_running_agents]
+      assert error.usage.running == 3
+    end
+
+    test "frees the slot once the agent's turn ends" do
+      rules = [rule(@ip_key, policy(max_running_agents: 1))]
+      for agent_id <- ~w(finished next), do: start_live_agent(agent_id)
+
+      assert :ok = RateLimiter.enforce!("finished", rules)
+      Repo.query!("UPDATE legion_agents SET status = 'idle' WHERE agent_id = $1", ["finished"])
+
+      assert :ok = RateLimiter.enforce!("next", rules)
+    end
+
+    test "does not count a running row whose agent is gone" do
+      insert_agent("crashed", @ip_key, status: "running")
+      start_live_agent("new")
+
+      assert :ok = RateLimiter.enforce!("new", [rule(@ip_key, policy(max_running_agents: 1))])
+    end
+
+    test "does not count a running row untouched since before the window" do
+      start_live_agent("stale")
+      insert_agent("stale", @ip_key, status: "running", updated_at: milliseconds_ago(2_000))
+      start_live_agent("new")
+
+      assert :ok =
+               RateLimiter.enforce!(
+                 "new",
+                 [rule(@ip_key, policy(window_ms: 1_000, max_running_agents: 1))]
+               )
+    end
+
+    test "leaves the status alone when no rule limits running agents" do
+      assert :ok = RateLimiter.enforce!("agent", [rule(@ip_key, policy())])
+
+      assert %{rows: [["idle"]]} =
+               Repo.query!("SELECT status FROM legion_agents WHERE agent_id = $1", ["agent"])
+    end
+
+    # The caller is marked running inside the locked transaction, so
+    # simultaneous starts count each other rather than all seeing zero.
+    test "allows exactly max_running_agents under concurrent calls" do
+      rules = [rule(@ip_key, policy(max_running_agents: 1))]
+      test_pid = self()
+
+      tasks =
+        for index <- 1..20 do
+          Task.async(fn ->
+            agent_id = "running-concurrent-#{index}"
+            :yes = Legion.AgentIndex.register_name(agent_id, self())
+            send(test_pid, {:ready, self()})
+
+            receive do
+              :enforce -> :ok
+            end
+
+            outcome =
+              try do
+                RateLimiter.enforce!(agent_id, rules)
+              rescue
+                ExceededError -> :exceeded
+              end
+
+            # A real agent stays alive for its whole turn, so hold the slot
+            # until every call has its verdict.
+            send(test_pid, {:outcome, self(), outcome})
+
+            receive do
+              :stop -> outcome
+            end
+          end)
+        end
+
+      for _ <- tasks, do: assert_receive({:ready, _})
+      Enum.each(tasks, &send(&1.pid, :enforce))
+      for _ <- tasks, do: assert_receive({:outcome, _, _}, 5_000)
+      Enum.each(tasks, &send(&1.pid, :stop))
+
+      outcomes = Enum.map(tasks, &Task.await(&1, 5_000))
+
+      assert Enum.count(outcomes, &(&1 == :ok)) == 1
+      assert Enum.count(outcomes, &(&1 == :exceeded)) == 19
+    end
+  end
+
   test "migration can be rolled back, reapplied, and rerun safely" do
     version = LegionAgentsMigration.version()
 
@@ -370,16 +465,25 @@ defmodule Legion.RateLimiter.PostgresDbTest do
     started_at = Keyword.get(opts, :started_at, NaiveDateTime.utc_now())
     usage = Keyword.get(opts, :usage, [])
     updated_at = Keyword.get(opts, :updated_at, NaiveDateTime.utc_now())
+    status = Keyword.get(opts, :status, "idle")
 
     Repo.query!(
       """
       INSERT INTO legion_agents (
-        agent_id, ratelimit_metadata, started_at, usage, updated_at
+        agent_id, ratelimit_metadata, started_at, usage, updated_at, status
       )
-      VALUES ($1, $2::jsonb, $3, $4::jsonb[], $5)
+      VALUES ($1, $2::jsonb, $3, $4::jsonb[], $5, $6)
       """,
-      [agent_id, key, started_at, usage, updated_at]
+      [agent_id, key, started_at, usage, updated_at, status]
     )
+  end
+
+  # The running limit only counts agents whose process is alive, so stand in
+  # for one under the id the way AgentServer registers itself.
+  defp start_live_agent(agent_id) do
+    pid = start_supervised!({Task, fn -> Process.sleep(:infinity) end}, id: agent_id)
+    :yes = Legion.AgentIndex.register_name(agent_id, pid)
+    pid
   end
 
   defp milliseconds_ago(milliseconds) do

--- a/test/legion/rate_limiter/postgres_db_test.exs
+++ b/test/legion/rate_limiter/postgres_db_test.exs
@@ -386,8 +386,6 @@ defmodule Legion.RateLimiter.PostgresDbTest do
                Repo.query!("SELECT status FROM legion_agents WHERE agent_id = $1", ["agent"])
     end
 
-    # The caller is marked running inside the locked transaction, so
-    # simultaneous starts count each other rather than all seeing zero.
     test "allows exactly max_running_agents under concurrent calls" do
       rules = [rule(@ip_key, policy(max_running_agents: 1))]
       test_pid = self()
@@ -478,8 +476,6 @@ defmodule Legion.RateLimiter.PostgresDbTest do
     )
   end
 
-  # The running limit only counts agents whose process is alive, so stand in
-  # for one under the id the way AgentServer registers itself.
   defp start_live_agent(agent_id) do
     pid = start_supervised!({Task, fn -> Process.sleep(:infinity) end}, id: agent_id)
     :yes = Legion.AgentIndex.register_name(agent_id, pid)


### PR DESCRIPTION
`:max_running_agents` in `Legion.RateLimiter.Policy` caps matching agents mid-turn at once. The Postgres adapter counts live agents and marks the caller running inside its transaction.
