### PR TITLE
Add message ref to usage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Rate limiting - `:max_running_agents` in [`Legion.RateLimiter.Policy`](https://hexdocs.pm/legion/Legion.RateLimiter.Policy.html) caps matching agents mid-turn at once; the Postgres adapter counts live agents and marks the caller running inside its transaction
 - Usage is persisted after every LLM request instead of at the end of the turn, so rate limits see a running turn's spend and a crashed turn keeps it
+- Usage entries carry `"message_index"`, the position in the stored conversation of the message their request produced
 
 ## v0.5.0 - 2026-09-01
 

--- a/lib/legion/executor.ex
+++ b/lib/legion/executor.ex
@@ -250,6 +250,8 @@ defmodule Legion.Executor do
       (response.usage || %{})
       |> normalize_usage()
       |> Map.put("at", System.system_time(:millisecond))
+      # system message skipped in persist
+      |> Map.put("message_index", length(messages) - 1)
 
     turn_usage = turn_usage ++ [usage]
     record_usage!(config, turn_usage)

--- a/lib/legion/store.ex
+++ b/lib/legion/store.ex
@@ -56,7 +56,8 @@ defmodule Legion.Store do
 
   Legion persists a string-keyed copy of `ReqLLM.Response.usage` for every LLM
   request in a conversation, ordered by request. Each map includes an `"at"`
-  Unix timestamp in milliseconds for when Legion received the response.
+  Unix timestamp in milliseconds for when Legion received the response, and a
+  `"message_index"`, the position in `:messages` of the message it produced.
   Tracking is enabled by default. Disable it globally before starting an agent:
 
       config :legion, :track_usage, false
@@ -88,9 +89,8 @@ defmodule Legion.Store do
   and `:retries` for step checkpoints. `:status` records whether the agent is
   mid-turn. The payload also carries the agent module, parent conversation,
   and start time when those values are known. Its `:usage` field is the ordered
-  list of string-keyed LLM usage maps when tracking is enabled. Each map's
-  `"at"` value is the Unix timestamp in milliseconds when Legion received the
-  response.
+  list of string-keyed LLM usage maps when tracking is enabled; see "Usage
+  tracking" for the `"at"` and `"message_index"` keys each map carries.
 
   With `binding_scope: :turn`, active bindings are included in step snapshots
   while the turn is running and cleared from the final snapshot. Bindings with

--- a/lib/legion/telemetry.ex
+++ b/lib/legion/telemetry.ex
@@ -42,7 +42,7 @@ defmodule Legion.Telemetry do
   - `[:legion, :llm, :request, :start | :stop | :exception]`
     - Metadata includes: `agent`, `agent_id`, `model`, `message_count`, `iteration`
     - Stop adds: `object` or `error`, and `usage` (the string-keyed usage map
-      with its `"at"` timestamp, when a response was received)
+      with its `"at"` timestamp and `"message_index"`, when a response was received)
 
   ## Sandbox Eval Events (spans)
 

--- a/test/legion/agent_server_test.exs
+++ b/test/legion/agent_server_test.exs
@@ -682,6 +682,34 @@ defmodule Legion.AgentServerTest do
       assert first_timestamp <= second_timestamp
     end
 
+    test "usage entries name the persisted assistant message their request produced" do
+      call_count = :counters.new(1, [:atomics])
+
+      stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+        :counters.add(call_count, 1, 1)
+
+        case :counters.get(call_count, 1) do
+          1 -> llm_eval_continue_response("x = 1", 7)
+          2 -> llm_response("first", 11)
+          3 -> llm_response("second", 13)
+        end
+      end)
+
+      {:ok, pid} = Legion.start_link(MathAgent, store: MemoryStore, agent_id: "usage-index")
+      assert {:ok, "first"} = Legion.call(pid, "first turn")
+      assert {:ok, "second"} = Legion.call(pid, "second turn")
+
+      assert {:ok, %Payload{usage: usage, conversation_state: %{messages: messages}}} =
+               MemoryStore.get("usage-index")
+
+      # [user, assistant, eval_result, assistant, user, assistant]
+      assert [%{"message_index" => 1}, %{"message_index" => 3}, %{"message_index" => 5}] = usage
+
+      for %{"message_index" => index} <- usage do
+        assert %{type: :assistant} = Enum.at(messages, index)
+      end
+    end
+
     test "persists usage after every LLM request, before the turn ends" do
       test_pid = self()
       call_count = :counters.new(1, [:atomics])

--- a/test/legion/executor_test.exs
+++ b/test/legion/executor_test.exs
@@ -632,6 +632,29 @@ defmodule Legion.ExecutorTest do
       assert {:usage_persistence_failed, %MatchError{term: :error}} = reason
       assert :counters.get(call_count, 1) == 1
     end
+
+    test "stamps each entry with the position of the message it produced" do
+      call_count = :counters.new(1, [:atomics])
+
+      stub(ReqLLM, :generate_object, fn _model, _messages, _schema ->
+        :counters.add(call_count, 1, 1)
+
+        case :counters.get(call_count, 1) do
+          1 -> response(nil, 7)
+          2 -> response(%{"action" => "return", "code" => "", "result" => "done"}, 11)
+        end
+      end)
+
+      # executor_messages/1 is [system, user]; the persisted list drops system,
+      # so the first request lands at 1, its error prompt fills 1, the retry at 2.
+      assert {:ok, "done", _messages, [], usage} =
+               Legion.Executor.run(MathAgent, executor_messages("compute"), %{})
+
+      assert [
+               %{"turn_usage" => 7, "message_index" => 1},
+               %{"turn_usage" => 11, "message_index" => 2}
+             ] = usage
+    end
   end
 
   describe "result formatting" do


### PR DESCRIPTION
This PR adds a `:message_index` reference to the persisted `:usage` field.

This PR is needed for [PR #19](https://github.com/software-mansion-labs/legion_web/pull/19) in legion_web